### PR TITLE
Implement AdamW & Lamb Optimizer; Optimize BERT model speed.

### DIFF
--- a/examples/nlp/bert/hetu_bert.py
+++ b/examples/nlp/bert/hetu_bert.py
@@ -564,8 +564,10 @@ class BertForPreTraining(object):
             next_sentence_loss: [batch_size]
             '''
 
-            masked_lm_loss = ht.softmaxcrossentropy_sparse_op(prediction_scores, masked_lm_labels, ignored_index=-1)
-            next_sentence_loss = ht.softmaxcrossentropy_sparse_op(seq_relationship_score, next_sentence_label, ignored_index=-1)
+            # masked_lm_loss = ht.softmaxcrossentropy_sparse_op(prediction_scores, masked_lm_labels, ignored_index=-1)
+            # next_sentence_loss = ht.softmaxcrossentropy_sparse_op(seq_relationship_score, next_sentence_label, ignored_index=-1)
+            masked_lm_loss = ht.crossentropy_sparse_op(ht.softmax_op(prediction_scores), masked_lm_labels, ignored_index=-1)
+            next_sentence_loss = ht.crossentropy_sparse_op(ht.softmax_op(seq_relationship_score), next_sentence_label,ignored_index=-1)
 
             return_op += [masked_lm_loss, next_sentence_loss]
         return return_op
@@ -630,7 +632,8 @@ class BertForMaskedLM(object):
 
             masked_lm_loss: [batch_size*seq_len]
             '''
-            masked_lm_loss = ht.softmaxcrossentropy_sparse_op(prediction_scores, masked_lm_labels, ignored_index=-1)
+            # masked_lm_loss = ht.softmaxcrossentropy_sparse_op(prediction_scores, masked_lm_labels, ignored_index=-1)
+            masked_lm_loss = ht.crossentropy_sparse_op(ht.softmax_op(prediction_scores), masked_lm_labels, ignored_index=-1)
             return_op += [masked_lm_loss]
 
         return return_op
@@ -695,7 +698,8 @@ class BertForNextSentencePrediction(object):
 
             next_sentence_loss: [batch_size]
             '''
-            next_sentence_loss = ht.softmaxcrossentropy_sparse_op(seq_relationship_score, next_sentence_label, ignored_index=-1)
+            # next_sentence_loss = ht.softmaxcrossentropy_sparse_op(seq_relationship_score, next_sentence_label, ignored_index=-1)
+            next_sentence_loss = ht.crossentropy_sparse_op(ht.softmax_op(seq_relationship_score), next_sentence_label,ignored_index=-1)
             return_op += [next_sentence_loss]
 
         return return_op
@@ -763,7 +767,8 @@ class BertForSequenceClassification(object):
         logits = self.classifier(pooled_output) # [batch_size, num_labels]
 
         if labels is not None:
-            loss = ht.softmaxcrossentropy_sparse_op(logits, labels, ignored_index = -1)
+            # loss = ht.softmaxcrossentropy_sparse_op(logits, labels, ignored_index = -1)
+            loss = ht.crossentropy_sparse_op(ht.softmax_op(logits), labels, ignored_index=-1)
             return loss, logits
         else:
             return logits
@@ -794,7 +799,7 @@ class Dropout(object):
     def __call__(self, input_tensor):
         if self.dropout_prob is None or self.dropout_prob == 0.0:
             return input_tensor
-        output = ht.dropout_op(input_tensor, 1.0 - self.dropout_prob)
+        output = ht.dropout_op(input_tensor, 1.0 - self.dropout_prob, recompute = True)
         return output
 
 class Linear(object):

--- a/examples/nlp/bert/train_pytorch_bert.py
+++ b/examples/nlp/bert/train_pytorch_bert.py
@@ -36,8 +36,8 @@ config = BertConfig(vocab_size=30522,
                     num_attention_heads=12, 
                     intermediate_size=3072, 
                     max_position_embeddings=512, 
-                    attention_probs_dropout_prob=0.0,
-                    hidden_dropout_prob=0.0,
+                    # attention_probs_dropout_prob=0.0,
+                    # hidden_dropout_prob=0.0,
                     batch_size=18)
 
 model = BertForPreTraining(config=config)

--- a/python/hetu/__init__.py
+++ b/python/hetu/__init__.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 from .gpu_ops import *
 from .context import context, get_current_context
 from .dataloader import dataloader_op, Dataloader, GNNDataLoaderOp
-from .ndarray import cpu, gpu, rcpu, rgpu, array, sparse_array, empty, is_gpu_ctx
+from .ndarray import cpu, gpu, rcpu, rgpu, array, sparse_array, empty, is_gpu_ctx, IndexedSlices
 from . import optimizer as optim
 from . import lr_scheduler as lr
 from . import initializers as init

--- a/python/hetu/gpu_links/CrossEntropyLink.py
+++ b/python/hetu/gpu_links/CrossEntropyLink.py
@@ -1,0 +1,22 @@
+from __future__ import absolute_import
+
+import ctypes
+from .._base import _LIB
+from .. import ndarray as _nd
+
+
+def cross_entropy(y, y_, out, stream=None):
+    assert isinstance(y, _nd.NDArray)
+    assert isinstance(y_, _nd.NDArray)
+    assert isinstance(out, _nd.NDArray)
+    _LIB.DLGpuCrossEntropy(
+        y.handle, y_.handle, out.handle, stream.handle if stream else None)
+
+
+def cross_entropy_gradient(grad_arr, y_arr, label, out_arr, stream=None):
+    assert isinstance(grad_arr, _nd.NDArray)
+    assert isinstance(y_arr, _nd.NDArray)
+    assert isinstance(label, _nd.NDArray)
+    assert isinstance(out_arr, _nd.NDArray)
+    _LIB.DLGpuCrossEntropyGradient(
+        grad_arr.handle, y_arr.handle, label.handle, out_arr.handle, stream.handle if stream else None)

--- a/python/hetu/gpu_links/CrossEntropySparseLink.py
+++ b/python/hetu/gpu_links/CrossEntropySparseLink.py
@@ -1,0 +1,22 @@
+from __future__ import absolute_import
+
+import ctypes
+from .._base import _LIB
+from .. import ndarray as _nd
+
+
+def cross_entropy_sparse(y, y_, ignored_index, out, stream=None):
+    assert isinstance(y, _nd.NDArray)
+    assert isinstance(y_, _nd.NDArray)
+    assert isinstance(out, _nd.NDArray)
+    _LIB.DLGpuCrossEntropySparse(
+        y.handle, y_.handle, ignored_index, out.handle, stream.handle if stream else None)
+
+
+def cross_entropy_sparse_gradient(grad_arr, y_arr, label, ignored_index, out_arr, stream=None):
+    assert isinstance(grad_arr, _nd.NDArray)
+    assert isinstance(y_arr, _nd.NDArray)
+    assert isinstance(label, _nd.NDArray)
+    assert isinstance(out_arr, _nd.NDArray)
+    _LIB.DLGpuCrossEntropySparseGradient(
+        grad_arr.handle, y_arr.handle, label.handle, ignored_index, out_arr.handle, stream.handle if stream else None)

--- a/python/hetu/gpu_links/DropoutLink.py
+++ b/python/hetu/gpu_links/DropoutLink.py
@@ -11,9 +11,15 @@ def dropout(in_arr, dropout_rate, out_arr, seed, stream=None):
     _LIB.DLGpuDropout(in_arr.handle, ctypes.c_float(
         dropout_rate), out_arr.handle, ctypes.byref(seed), stream.handle if stream else None)
 
-
-def dropout_gradient(grad_arr, dropout_rate, out_arr, seed, stream=None):
+def dropout_gradient_recompute(grad_arr, dropout_rate, out_arr, seed, stream=None):
     assert isinstance(grad_arr, _nd.NDArray)
     assert isinstance(out_arr, _nd.NDArray)
-    _LIB.DLGpuDropoutGradient(grad_arr.handle, ctypes.c_float(
+    _LIB.DLGpuDropoutGradient_recompute(grad_arr.handle, ctypes.c_float(
         dropout_rate), out_arr.handle, seed, stream.handle if stream else None)
+
+def dropout_gradient(grad_arr, fw_output_arr, dropout_rate, out_arr, stream=None):
+    assert isinstance(grad_arr, _nd.NDArray)
+    assert isinstance(fw_output_arr, _nd.NDArray)
+    assert isinstance(out_arr, _nd.NDArray)
+    _LIB.DLGpuDropoutGradient(grad_arr.handle, fw_output_arr.handle, ctypes.c_float(
+        dropout_rate), out_arr.handle, stream.handle if stream else None)

--- a/python/hetu/gpu_links/OptimizerLink.py
+++ b/python/hetu/gpu_links/OptimizerLink.py
@@ -82,3 +82,35 @@ def adam_update(param, grad, expavg, expavgsq, lr, beta1, beta2, beta1t, beta2t,
                                        ctypes.c_float(beta1t), ctypes.c_float(beta2t), ctypes.c_float(eps), stream.handle if stream else None)
         grad.free_deduplicate()
         grad.free_dense()
+
+def adamw_update(param, grad, expavg, expavgsq, lr, beta1, beta2, beta1t, beta2t, eps, weight_decay, stream=None):
+    assert isinstance(param, _nd.NDArray)
+    assert isinstance(grad, (_nd.NDArray, _nd.IndexedSlices))
+    assert isinstance(expavg, _nd.NDArray)
+    assert isinstance(expavgsq, _nd.NDArray)
+    if isinstance(grad, _nd.NDArray):
+        _LIB.AdamWOptimizerUpdate(param.handle, grad.handle, expavg.handle, expavgsq.handle, ctypes.c_float(lr), ctypes.c_float(beta1), ctypes.c_float(beta2),
+                                 ctypes.c_float(beta1t), ctypes.c_float(beta2t), ctypes.c_float(eps), ctypes.c_float(weight_decay), stream.handle if stream else None)
+    else:
+        grad.deduplicate(stream)
+        assert isinstance(grad.indices, _nd.NDArray)
+        assert isinstance(grad.values, _nd.NDArray)
+        _LIB.AdamWOptimizerSparseUpdate(param.handle, grad.indices.handle, grad.values.handle, expavg.handle, expavgsq.handle, ctypes.c_float(lr), ctypes.c_float(beta1), ctypes.c_float(beta2),
+                                       ctypes.c_float(beta1t), ctypes.c_float(beta2t), ctypes.c_float(eps), ctypes.c_float(weight_decay), stream.handle if stream else None)
+        grad.free_deduplicate()
+
+def lamb_update(param, grad, expavg, expavgsq, lr, beta1, beta2, beta1t, beta2t, eps, weight_decay, stream=None):
+    assert isinstance(param, _nd.NDArray)
+    assert isinstance(grad, (_nd.NDArray, _nd.IndexedSlices))
+    assert isinstance(expavg, _nd.NDArray)
+    assert isinstance(expavgsq, _nd.NDArray)
+    if isinstance(grad, _nd.NDArray):
+        _LIB.LambOptimizerUpdate(param.handle, grad.handle, expavg.handle, expavgsq.handle, ctypes.c_float(lr), ctypes.c_float(beta1), ctypes.c_float(beta2),
+                                 ctypes.c_float(beta1t), ctypes.c_float(beta2t), ctypes.c_float(eps), ctypes.c_float(weight_decay), stream.handle if stream else None)
+    else:
+        grad.deduplicate(stream)
+        assert isinstance(grad.indices, _nd.NDArray)
+        assert isinstance(grad.values, _nd.NDArray)
+        _LIB.LambOptimizerSparseUpdate(param.handle, grad.indices.handle, grad.values.handle, expavg.handle, expavgsq.handle, ctypes.c_float(lr), ctypes.c_float(beta1), ctypes.c_float(beta2),
+                                       ctypes.c_float(beta1t), ctypes.c_float(beta2t), ctypes.c_float(eps), ctypes.c_float(weight_decay), stream.handle if stream else None)
+        grad.free_deduplicate()

--- a/python/hetu/gpu_links/__init__.py
+++ b/python/hetu/gpu_links/__init__.py
@@ -51,6 +51,8 @@ from .DropoutLink import *
 from .Dropout2dLink import *
 from .CudnnSoftmaxLink import *
 from .CudnnSoftmaxCrossEntropyLink import *
+from .CrossEntropyLink import *
+from .CrossEntropySparseLink import *
 from .OneHotLink import *
 from .InitializersLink import *
 from .DotLink import *
@@ -156,5 +158,9 @@ __all__ = [
     'binary_cross_entropy_gradient',
     'matrix_dot',
     'gelu',
-    'gelu_gradient'
+    'gelu_gradient',
+    'cross_entropy',
+    'cross_entropy_gradient',
+    'cross_entropy_sparse',
+    'cross_entropy_sparse_gradient',
 ]

--- a/python/hetu/gpu_ops/CrossEntropy.py
+++ b/python/hetu/gpu_ops/CrossEntropy.py
@@ -1,0 +1,108 @@
+from __future__ import absolute_import
+import numpy as np
+from .Node import Op
+from .._base import DNNL_LIB
+from .Softmax import softmax_func
+from ..gpu_links import cross_entropy
+from ..gpu_links import cross_entropy_gradient
+
+
+class CrossEntropyOp(Op):
+    def __init__(self, node_y, node_y_, ctx=None):
+        super().__init__(CrossEntropyOp, [node_y, node_y_], ctx)
+
+    def compute(self, input_vals, output_val, stream_handle=None):
+        y = input_vals[0]
+        y_ = input_vals[1]
+        if self.on_cpu:
+            output_val[:] = -np.sum(y_.asnumpy() * np.log(y.asnumpy()), axis=1)
+        else:
+            cross_entropy(y, y_, output_val, stream_handle)
+
+    def gradient(self, output_grad):
+        grad_A = crossentropy_gradient_op(
+            output_grad, self.inputs[0], self.inputs[1], ctx=self.raw_ctx)
+        return [grad_A, None]
+
+    def infer_shape(self, input_shapes):
+        assert len(input_shapes) == 2
+        assert len(input_shapes[0]) >= 2
+        return input_shapes[0][:-1]
+
+    def forward_deduce_states(self, input_statuses, status, deduce_order):
+        # only allow data parallel in softmax cross entropy
+        assert len(input_statuses) == len(self.inputs)
+        for nst in input_statuses:
+            if nst.valid(deduce_order):
+                nst.check_state(1, deduce_order)
+                status.copy_from(nst, deduce_order)
+
+    def backward_deduce_states(self, status, input_statuses, deduce_order):
+        # only allow data parallel in softmax cross entropy
+        assert len(input_statuses) == len(self.inputs)
+        if status.valid(deduce_order):
+            status.check_state(1, deduce_order)
+            for nst in input_statuses:
+                nst.copy_from(status, deduce_order)
+
+
+class CrossEntropyGradientOp(Op):
+    def __init__(self, node_grad, node_y, node_y_, ctx=None):
+        super().__init__(CrossEntropyGradientOp,
+                         [node_grad, node_y, node_y_], ctx)
+
+    def compute(self, input_vals, output_val, stream_handle=None):
+        if self.on_cpu:
+            grad = input_vals[0].asnumpy()
+            y = input_vals[1].asnumpy()
+            y_ = input_vals[2].asnumpy()
+            output_val[:] = - y_ / y * np.expand_dims(grad, -1)
+        else:
+            crossentropy_gradient_op(
+                input_vals[0], input_vals[1], input_vals[2], output_val, stream_handle)
+
+    def gradient(self, output_grad):
+        raise NotImplementedError
+
+    def infer_shape(self, input_shapes):
+        assert len(input_shapes) == 3
+        return input_shapes[1]
+
+    def forward_deduce_states(self, input_statuses, status, deduce_order):
+        # only allow data parallel in softmax cross entropy
+        assert len(input_statuses) == len(self.inputs)
+        for nst in input_statuses:
+            if nst.valid(deduce_order):
+                nst.check_state(1, deduce_order)
+                status.copy_from(nst, deduce_order)
+
+    def backward_deduce_states(self, status, input_statuses, deduce_order):
+        # only allow data parallel in softmax cross entropy
+        assert len(input_statuses) == len(self.inputs)
+        if status.valid(deduce_order):
+            status.check_state(1, deduce_order)
+            for nst in input_statuses:
+                nst.copy_from(status, deduce_order)
+
+
+def crossentropy_op(node_y, node_y_, ctx=None):
+    """Computes cross entropy loss for pre-softmax activations.
+
+    Parameters:
+    ----
+    node_A : Node
+        Predicted probability.
+    node_B : Node
+        Labels.
+
+    Returns:
+    ----
+    A new Node instance created by Op.
+
+    """
+
+    return CrossEntropyOp(node_y, node_y_, ctx=ctx)
+
+
+def crossentropy_gradient_op(node_grad, node_y, node_y_, ctx=None):
+    return CrossEntropyGradientOp(node_grad, node_y, node_y_, ctx=ctx)

--- a/python/hetu/gpu_ops/CrossEntropySparse.py
+++ b/python/hetu/gpu_ops/CrossEntropySparse.py
@@ -1,0 +1,55 @@
+from __future__ import absolute_import
+import numpy as np
+from .Node import Op
+from .._base import DNNL_LIB
+from ..gpu_links import cross_entropy_sparse
+from ..gpu_links import cross_entropy_sparse_gradient
+
+
+class SoftmaxCrossEntropySparseOp(Op):
+    def __init__(self, node_y, node_y_, ignored_index, ctx=None):
+        super().__init__(SoftmaxCrossEntropySparseOp, [node_y, node_y_], ctx)
+        self.ignored_index = ignored_index
+
+    def compute(self, input_vals, output_val, stream_handle=None):
+        y = input_vals[0]
+        y_ = input_vals[1]
+        cross_entropy_sparse(
+            y, y_, self.ignored_index, output_val, stream_handle)
+
+    def gradient(self, output_grad):
+        grad_A = crossentropy_sparse_gradient_op(
+            output_grad, self.inputs[0], self.inputs[1], self.ignored_index, ctx=output_grad.ctx)
+        return [grad_A, None]
+
+    def infer_shape(self, input_shapes):
+        assert len(input_shapes) == 2
+        assert len(input_shapes[0]) >= 2
+        assert input_shapes[0][:-1] == input_shapes[1]
+        return input_shapes[0][:-1]
+
+
+class SoftmaxCrossEntropySparseGradientOp(Op):
+    def __init__(self, node_grad, node_y, node_y_, ignored_index, ctx=None):
+        super().__init__(SoftmaxCrossEntropySparseGradientOp,
+                         [node_grad, node_y, node_y_], ctx)
+        self.ignored_index = ignored_index
+
+    def compute(self, input_vals, output_val, stream_handle=None):
+        cross_entropy_sparse_gradient(
+            input_vals[0], input_vals[1], input_vals[2], self.ignored_index, output_val, stream_handle)
+
+    def gradient(self, output_grad):
+        raise NotImplementedError
+
+    def infer_shape(self, input_shapes):
+        assert len(input_shapes) == 3
+        return input_shapes[1]
+
+
+def crossentropy_sparse_op(node_y, node_y_, ignored_index=-1, ctx=None):
+    return SoftmaxCrossEntropySparseOp(node_y, node_y_, ignored_index, ctx=ctx)
+
+
+def crossentropy_sparse_gradient_op(node_grad, node_y, node_y_, ignored_index, ctx=None):
+    return SoftmaxCrossEntropySparseGradientOp(node_grad, node_y, node_y_, ignored_index, ctx=ctx)

--- a/python/hetu/gpu_ops/__init__.py
+++ b/python/hetu/gpu_ops/__init__.py
@@ -33,6 +33,8 @@ from .Slice import slice_op, slice_gradient_op
 from .Softmax import softmax_func, softmax_op
 from .SoftmaxCrossEntropy import softmaxcrossentropy_op
 from .SoftmaxCrossEntropySparse import softmaxcrossentropy_sparse_op
+from .CrossEntropy import crossentropy_op
+from .CrossEntropySparse import crossentropy_sparse_op
 from .Split import split_op, split_gradient_op
 from .Sqrt import sqrt_op, rsqrt_op
 from .Sum import sum_op
@@ -124,6 +126,8 @@ __all__ = [
     'softmax_op',
     'softmaxcrossentropy_op',
     'softmaxcrossentropy_sparse_op',
+    'crossentropy_op',
+    'crossentropy_sparse_op',
     'split_op',
     'split_gradient_op',
     'sqrt_op',

--- a/src/common/c_runtime_api.h
+++ b/src/common/c_runtime_api.h
@@ -644,6 +644,30 @@ HETUSYS_EXTERN_C {
         DLArrayHandle expavgsq, float lr, float beta1, float beta2,
         float beta1t, float beta2t, float eps, DLStreamHandle stream_handle);
 
+    int AdamWOptimizerUpdate(
+        DLArrayHandle param, const DLArrayHandle grad, DLArrayHandle expavg,
+        DLArrayHandle expavgsq, float lr, float beta1, float beta2,
+        float beta1t, float beta2t, float eps, float weight_decay, 
+        DLStreamHandle stream_handle);
+    int AdamWOptimizerSparseUpdate(
+        DLArrayHandle param, const DLArrayHandle grad_indices,
+        const DLArrayHandle grad_values, DLArrayHandle expavg,
+        DLArrayHandle expavgsq, float lr, float beta1, float beta2,
+        float beta1t, float beta2t, float eps, float weight_decay, 
+        DLStreamHandle stream_handle);
+
+    int LambOptimizerUpdate(
+        DLArrayHandle param, const DLArrayHandle grad, DLArrayHandle expavg,
+        DLArrayHandle expavgsq, float lr, float beta1, float beta2,
+        float beta1t, float beta2t, float eps, float weight_decay, 
+        DLStreamHandle stream_handle);
+    int LambOptimizerSparseUpdate(
+        DLArrayHandle param, const DLArrayHandle grad_indices,
+        const DLArrayHandle grad_values, DLArrayHandle expavg,
+        DLArrayHandle expavgsq, float lr, float beta1, float beta2,
+        float beta1t, float beta2t, float eps, float weight_decay, 
+        DLStreamHandle stream_handle);
+
     int DeduplicateIndexedSlices(
         const DLArrayHandle origin, const DLArrayHandle inverse,
         DLArrayHandle compressed, DLStreamHandle stream_handle);

--- a/src/common/c_runtime_api.h
+++ b/src/common/c_runtime_api.h
@@ -330,6 +330,29 @@ HETUSYS_EXTERN_C {
         const DLArrayHandle input_c, DLArrayHandle output,
         DLStreamHandle stream_handle);
 
+    int DLGpuCrossEntropy(const DLArrayHandle input_y,
+        const DLArrayHandle label, DLArrayHandle output,
+        DLStreamHandle stream_handle);
+
+    int DLGpuCrossEntropyGradient(const DLArrayHandle grad,
+                                      const DLArrayHandle input_y,
+                                      const DLArrayHandle label,
+                                      DLArrayHandle output,
+                                      DLStreamHandle stream_handle);
+
+    int DLGpuCrossEntropySparse(const DLArrayHandle input_y,
+                              const DLArrayHandle label, 
+                              const int ignored_index,
+                              DLArrayHandle output,
+                              DLStreamHandle stream_handle);
+    
+    int DLGpuCrossEntropySparseGradient(const DLArrayHandle grad,
+                                      const DLArrayHandle input_y,
+                                      const DLArrayHandle label,
+                                      const int ignored_index,
+                                      DLArrayHandle output,
+                                      DLStreamHandle stream_handle);
+
     int DLGpuConv2d(const DLArrayHandle input_x, const DLArrayHandle input_f,
                     DLArrayHandle output, DLArrayHandle workspace_arr,
                     const int padding, const int stride,
@@ -551,9 +574,15 @@ HETUSYS_EXTERN_C {
                      DLArrayHandle output, unsigned long long *pseed,
                      DLStreamHandle stream_handle);
 
-    int DLGpuDropoutGradient(const DLArrayHandle grad, const float dropout,
+    
+    int DLGpuDropoutGradient_recompute(const DLArrayHandle grad, const float dropout,
                              DLArrayHandle output, unsigned long long seed,
                              DLStreamHandle stream_handle);
+    
+
+    int DLGpuDropoutGradient(const DLArrayHandle grad, const DLArrayHandle fw_output,
+                         const float dropout, DLArrayHandle output,
+                         DLStreamHandle stream_handle);
 
     int DLGpuDropout2d(const DLArrayHandle input, const float dropout,
                        DLArrayHandle output, unsigned long long *pseed,

--- a/src/ops/CrossEntropy.cu
+++ b/src/ops/CrossEntropy.cu
@@ -1,0 +1,128 @@
+#include "gpu_runtime.h"
+
+__global__ void cross_entropy_kernel(const float *y,
+                                           const float *y_, float *output,
+                                           size_t size) {
+    size_t idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx >= size)
+        return;
+    output[idx] = -log(y[idx]) * y_[idx];
+}
+
+int DLGpuCrossEntropy(const DLArrayHandle input_y,
+                              const DLArrayHandle label, DLArrayHandle output,
+                              DLStreamHandle stream_handle = NULL) {
+    size_t indim = input_y->ndim;
+    assert(indim == label->ndim && indim == output->ndim + 1);
+    int dev_id = (input_y->ctx).device_id;
+    cudnn_init(dev_id, stream_handle);
+    int n_ = 1;
+    for (int i = 0; i < indim - 1; ++i) {
+        n_ *= input_y->shape[i];
+    }
+    int c_ = input_y->shape[indim - 1];
+    size_t size = n_ * c_;
+    const float *y_data = (const float *)(input_y->data);
+    float *label_data = (float *)(label->data);
+    float *output_data = (float *)(output->data);
+    float alpha = 1.0f;
+    float beta = 0.0f;
+    cudnnTensorDescriptor_t desc;
+    CUDNN_CALL(cudnnCreateTensorDescriptor(&desc));
+    CUDNN_CALL(cudnnSetTensor4dDescriptor(desc, CUDNN_TENSOR_NCHW,
+                                          CUDNN_DATA_FLOAT, n_, c_, 1, 1));
+    if (is_chunk_init(dev_id) == false) {
+        chunk_init(dev_id);
+    }
+    void *temp_data = find_chunk(size * sizeof(float), dev_id);
+
+    dim3 blocks;
+    dim3 threads;
+    if (size <= 1024) {
+        threads.x = size;
+        blocks.x = 1;
+    } else {
+        threads.x = 1024;
+        blocks.x = (size + 1023) / 1024;
+    }
+
+    // Compute -log(yi)*yi_
+    if (stream_handle) {
+        cross_entropy_kernel<<<blocks, threads, 0,
+                                     *(cudaStream_t *)stream_handle->handle>>>(
+            y_data, label_data, (float *)temp_data, size);
+    } else {
+        cross_entropy_kernel<<<blocks, threads>>>(
+            y_data, label_data, (float *)temp_data, size);
+    }
+
+    // Compute Sigma(-log(yi)*yi_)
+    cudnnReduceTensorDescriptor_t rtd;
+    CUDNN_CALL(cudnnCreateReduceTensorDescriptor(&rtd));
+    CUDNN_CALL(cudnnSetReduceTensorDescriptor(
+        rtd, CUDNN_REDUCE_TENSOR_ADD, CUDNN_DATA_FLOAT, CUDNN_PROPAGATE_NAN,
+        CUDNN_REDUCE_TENSOR_NO_INDICES, CUDNN_32BIT_INDICES));
+    cudnnTensorDescriptor_t new_desc;
+    CUDNN_CALL(cudnnCreateTensorDescriptor(&new_desc));
+    CUDNN_CALL(cudnnSetTensor4dDescriptor(new_desc, CUDNN_TENSOR_NCHW,
+                                          CUDNN_DATA_FLOAT, n_, 1, 1, 1));
+    CUDNN_CALL(cudnnReduceTensor(cudnn_map[dev_id], rtd, NULL, 0, temp_data,
+                                 size * sizeof(float), &alpha, desc,
+                                 (const void *)temp_data, &beta, new_desc,
+                                 (void *)output_data));
+
+    CUDNN_CALL(cudnnDestroyReduceTensorDescriptor(rtd));
+    CUDNN_CALL(cudnnDestroyTensorDescriptor(new_desc));
+    CUDNN_CALL(cudnnDestroyTensorDescriptor(desc));
+    del_chunk(temp_data, dev_id);
+    return 0;
+}
+
+__global__ void cross_entropy_gradient_kernel(const float *y, const float *y_,
+                                     const float *grad_data, float *output_data,
+                                     int last_dim, size_t size) {
+    size_t ind = blockIdx.x * blockDim.x + threadIdx.x;
+    if (ind >= size)
+        return;
+    output_data[ind] = - y_[ind] / y[ind] * grad_data[ind / last_dim];
+}
+
+int DLGpuCrossEntropyGradient(const DLArrayHandle grad,
+                                      const DLArrayHandle input_y,
+                                      const DLArrayHandle label,
+                                      DLArrayHandle output,
+                                      DLStreamHandle stream_handle = NULL) {
+    size_t indim = input_y->ndim;
+    assert(indim == label->ndim && indim == output->ndim
+           && indim == grad->ndim + 1);
+
+    int n_ = 1;
+    for (int i = 0; i < indim - 1; ++i) {
+        n_ *= input_y->shape[i];
+    }
+    int c_ = input_y->shape[indim - 1];
+    size_t size = n_ * c_;
+    const float *grad_data = (const float *)grad->data;
+    const float *y_data = (const float *)input_y->data;
+    const float *label_data = (const float *)label->data;
+    float *output_data = (float *)output->data;
+
+    dim3 blocks;
+    dim3 threads;
+    if (size <= 1024) {
+        threads.x = size;
+        blocks.x = 1;
+    } else {
+        threads.x = 1024;
+        blocks.x = (size + 1023) / 1024;
+    }
+    if (stream_handle) {
+        cross_entropy_gradient_kernel<<<
+            blocks, threads, 0, *(cudaStream_t *)stream_handle->handle>>>(
+            y_data, label_data, grad_data, output_data, c_, size);
+    } else {
+        cross_entropy_gradient_kernel<<<blocks, threads>>>(
+            y_data, label_data, grad_data, output_data, c_, size);
+    }
+    return 0;
+}

--- a/src/ops/CrossEntropySparse.cu
+++ b/src/ops/CrossEntropySparse.cu
@@ -1,0 +1,118 @@
+#include "gpu_runtime.h"
+
+__global__ void cross_entropy_sparse_kernel(const float *y,
+                                            const float *y_, float *output,
+                                            const int ignored_index,
+                                            int nrow, int ncol) {
+    size_t idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx >= nrow)
+        return;
+    int pos = int(y_[idx]);
+    if(pos == ignored_index || pos < 0){
+        output[idx] = 0;
+        return;
+    }
+    int y_pos = idx * ncol + pos;
+    output[idx] = -log(y[y_pos]);
+}
+
+int DLGpuCrossEntropySparse(const DLArrayHandle input_y,
+                              const DLArrayHandle label, 
+                              const int ignored_index,
+                              DLArrayHandle output,
+                              DLStreamHandle stream_handle = NULL) {
+    size_t indim = input_y->ndim;
+    assert(indim == label->ndim + 1 && indim == output->ndim + 1);
+    size_t nrow = 1;
+    for (int i = 0; i < indim - 1; ++i) {
+        nrow *= input_y->shape[i];
+    }
+    int ncol = input_y->shape[indim - 1];
+    size_t size = nrow;
+    const float *y_data = (const float *)(input_y->data);
+    const float *label_data = (const float *)(label->data);
+    float *output_data = (float *)(output->data);
+
+    dim3 blocks;
+    dim3 threads;
+    if (size <= 1024) {
+        threads.x = size;
+        blocks.x = 1;
+    } else {
+        threads.x = 1024;
+        blocks.x = (size + 1023) / 1024;
+    }
+
+    if (stream_handle) {
+        cross_entropy_sparse_kernel<<<blocks, threads, 0,
+                                     *(cudaStream_t *)stream_handle->handle>>>(
+            y_data, label_data, output_data, ignored_index, nrow, ncol);
+    } else {
+        cross_entropy_sparse_kernel<<<blocks, threads>>>(
+            y_data, label_data, output_data, ignored_index, nrow, ncol);
+    }
+    return 0;
+}
+
+__global__ void cross_entropy_sparse_gradient_kernel(const float *y, const float *y_,
+                                     const float *grad_data, float *output_data,
+                                     const int ignored_index, int length, size_t size) {
+    size_t thread_ind = blockIdx.x * blockDim.x + threadIdx.x;
+    if (thread_ind >= size)
+        return;
+    size_t ind = thread_ind / length;
+    size_t offset = thread_ind % length;
+    int pos = int(y_[ind]);
+    if(pos == ignored_index || pos < 0){
+        output_data[thread_ind] = 0;
+        return;
+    }
+    if(pos != offset){
+        output_data[thread_ind] = 0;
+        return;
+    }
+    output_data[thread_ind] = - 1.0 / y[thread_ind] * grad_data[ind];
+}
+
+int DLGpuCrossEntropySparseGradient(const DLArrayHandle grad,
+                                      const DLArrayHandle input_y,
+                                      const DLArrayHandle label,
+                                      const int ignored_index,
+                                      DLArrayHandle output,
+                                      DLStreamHandle stream_handle = NULL) {
+    size_t indim = input_y->ndim;
+    assert(indim == label->ndim + 1 && indim == output->ndim
+           && indim == grad->ndim + 1);
+
+    int nrow = 1;
+    for (int i = 0; i < indim - 1; ++i) {
+        nrow *= input_y->shape[i];
+    }
+    int ncol = input_y->shape[indim - 1];
+    size_t size = nrow * ncol;
+    const float *grad_data = (const float *)grad->data;
+    const float *y_data = (const float *)input_y->data;
+    const float *label_data = (const float *)label->data;
+    float *output_data = (float *)output->data;
+
+    dim3 blocks;
+    dim3 threads;
+    if (size <= 1024) {
+        threads.x = size;
+        blocks.x = 1;
+    } else {
+        threads.x = 1024;
+        blocks.x = (size + 1023) / 1024;
+    }
+    if (stream_handle) {
+        cross_entropy_sparse_gradient_kernel<<<
+            blocks, threads, 0, *(cudaStream_t *)stream_handle->handle>>>(
+            y_data, label_data, grad_data, output_data, ignored_index, ncol,
+            size);
+    } else {
+        cross_entropy_sparse_gradient_kernel<<<blocks, threads>>>(
+            y_data, label_data, grad_data, output_data, ignored_index, ncol,
+            size);
+    }
+    return 0;
+}

--- a/src/ops/Optimizers.cu
+++ b/src/ops/Optimizers.cu
@@ -214,3 +214,190 @@ int AdamOptimizerUpdate(DLArrayHandle param, const DLArrayHandle grad,
                                          size);
     return 0;
 }
+
+__global__ void adamw_update(float *param, const float *grad, float *m, float *v,
+                            float lr, float beta1, float beta2, float beta1t,
+                            float beta2t, float eps, float weight_decay, size_t size) {
+    size_t ind = blockIdx.x * blockDim.x + threadIdx.x;
+    if (ind >= size)
+        return;
+    m[ind] = beta1 * m[ind] + (1 - beta1) * grad[ind];
+    v[ind] = beta2 * v[ind] + (1 - beta2) * grad[ind] * grad[ind];
+    float m_local = m[ind] / (1 - beta1t);
+    float v_local = v[ind] / (1 - beta2t);
+    float update = m_local / (sqrtf(v_local) + eps);
+    param[ind] = param[ind] - lr * (update + weight_decay * param[ind]);
+}
+
+int AdamWOptimizerUpdate(DLArrayHandle param, const DLArrayHandle grad,
+                        DLArrayHandle expavg, DLArrayHandle expavgsq, float lr,
+                        float beta1, float beta2, float beta1t, float beta2t,
+                        float eps, float weight_decay, DLStreamHandle stream_handle = NULL) {
+    size_t size = 1;
+    for (index_t i = 0; i < param->ndim; ++i) {
+        size *= param->shape[i];
+    }
+    dim3 blocks;
+    dim3 threads;
+    float *param_data = (float *)param->data;
+    const float *grad_data = (const float *)grad->data;
+    float *m_data = (float *)expavg->data;
+    float *v_data = (float *)expavgsq->data;
+    if (size <= 1024) {
+        threads.x = size;
+        blocks.x = 1;
+    } else {
+        threads.x = 1024;
+        blocks.x = (size + 1023) / 1024;
+    }
+    if (stream_handle)
+        adamw_update<<<blocks, threads, 0,
+                      *(cudaStream_t *)stream_handle->handle>>>(
+            param_data, grad_data, m_data, v_data, lr, beta1, beta2, beta1t,
+            beta2t, eps, weight_decay, size);
+    else
+        adamw_update<<<blocks, threads>>>(param_data, grad_data, m_data, v_data,
+                                         lr, beta1, beta2, beta1t, beta2t, eps,
+                                         weight_decay, size);
+    return 0;
+}
+
+__global__ void calc_lamb_update(float *update, const float *grad, float *m, float *v,
+                            float beta1, float beta2, float beta1t,
+                            float beta2t, float eps, size_t size) {
+    size_t ind = blockIdx.x * blockDim.x + threadIdx.x;
+    if (ind >= size)
+        return;
+    m[ind] = beta1 * m[ind] + (1 - beta1) * grad[ind];
+    v[ind] = beta2 * v[ind] + (1 - beta2) * grad[ind] * grad[ind];
+    float m_local = m[ind] / (1 - beta1t);
+    float v_local = v[ind] / (1 - beta2t);
+    update[ind] = m_local / (sqrtf(v_local) + eps);
+}
+
+__global__ void lamb_update_step(float *param, const float *update, float lr, 
+                                float weight_decay, float *norm2_param, float *norm2_update, size_t size){
+    size_t ind = blockIdx.x * blockDim.x + threadIdx.x;
+    if (ind >= size)
+        return;
+    param[ind] = param[ind] - lr * (norm2_param[0] / norm2_update[0]) * (update[ind] + weight_decay * param[ind]);
+}
+
+int LambOptimizerUpdate(DLArrayHandle param, const DLArrayHandle grad,
+                        DLArrayHandle expavg, DLArrayHandle expavgsq, float lr,
+                        float beta1, float beta2, float beta1t, float beta2t,
+                        float eps, float weight_decay, DLStreamHandle stream_handle = NULL) {
+    int dev_id = (param->ctx).device_id;
+    cudaSetDevice(dev_id);
+    cudnn_init(dev_id, stream_handle);
+
+    // Prepare cudnn reduce tensor for Norm2 calculation of param and update
+    float one = 1.0f;
+    float zero = 0.0f;
+
+    cudnnReduceTensorDescriptor_t rtd;
+    CUDNN_CALL(cudnnCreateReduceTensorDescriptor(&rtd));
+    CUDNN_CALL(cudnnSetReduceTensorDescriptor(
+        rtd, CUDNN_REDUCE_TENSOR_NORM2, CUDNN_DATA_FLOAT, CUDNN_PROPAGATE_NAN,
+        CUDNN_REDUCE_TENSOR_NO_INDICES, CUDNN_32BIT_INDICES));
+
+    cudnnTensorDescriptor_t adesc;
+    cudnnTensorDescriptor_t cdesc;
+    CUDNN_CALL(cudnnCreateTensorDescriptor(&adesc));
+    CUDNN_CALL(cudnnCreateTensorDescriptor(&cdesc));
+
+    int ndim = param->ndim;
+    if (ndim < 4)
+        ndim = 4;
+    size_t cpu_mem = ndim * sizeof(int);
+    int *dimA = (int *)malloc(cpu_mem);
+    int *strideA = (int *)malloc(cpu_mem);
+    int *dimC = (int *)malloc(cpu_mem);
+    int *strideC = (int *)malloc(cpu_mem);
+
+    int temp_strideA = 1;
+    int temp_strideC = 1;
+
+    for (int i = ndim - 1; i >= 0; --i) {
+        dimA[i] = i < param->ndim ? (int)param->shape[i] : 1;
+        dimC[i] = 1;
+        strideA[i] = temp_strideA;
+        strideC[i] = temp_strideC;
+        temp_strideA *= dimA[i];
+        temp_strideC *= dimC[i];
+    }
+    size_t size = temp_strideA * sizeof(float);
+
+    CUDNN_CALL(cudnnSetTensorNdDescriptor(adesc, CUDNN_DATA_FLOAT, ndim, dimA,
+                                            strideA));
+    CUDNN_CALL(cudnnSetTensorNdDescriptor(cdesc, CUDNN_DATA_FLOAT, ndim, dimC,
+                                            strideC));
+
+    dim3 blocks;
+    dim3 threads;
+    float *param_data = (float *)param->data;
+    const float *grad_data = (const float *)grad->data;
+    float *m_data = (float *)expavg->data;
+    float *v_data = (float *)expavgsq->data;
+    if (temp_strideA <= 1024) {
+        threads.x = temp_strideA;
+        blocks.x = 1;
+    } else {
+        threads.x = 1024;
+        blocks.x = (temp_strideA + 1023) / 1024;
+    }
+
+    if (is_chunk_init(dev_id) == false) {
+        chunk_init(dev_id);
+    }
+    void *norm2_param = find_chunk(1 * sizeof(float), dev_id);
+    void *norm2_update = find_chunk(1 * sizeof(float), dev_id);
+    void *workspace = find_chunk(size, dev_id);
+    void *update = find_chunk(size, dev_id);
+
+    // Calculate Norm2 of param
+    CUDNN_CALL(cudnnReduceTensor(cudnn_map[dev_id], rtd, NULL, 0,
+                                    workspace, size, &one, adesc,
+                                    (const void *)param_data, &zero, cdesc,
+                                    norm2_param));
+
+    // Calculate update
+    if (stream_handle)
+        calc_lamb_update<<<blocks, threads, 0,
+                      *(cudaStream_t *)stream_handle->handle>>>(
+            (float *)update, grad_data, m_data, v_data, beta1, beta2, beta1t,
+            beta2t, eps, temp_strideA);
+    else
+        calc_lamb_update<<<blocks, threads>>>((float *)update, grad_data, m_data, v_data,
+                                         beta1, beta2, beta1t, beta2t, eps,
+                                         temp_strideA);
+
+    // Calculate Norm2 of update
+    CUDNN_CALL(cudnnReduceTensor(cudnn_map[dev_id], rtd, NULL, 0,
+                                workspace, size, &one, adesc,
+                                (const void *)update, &zero, cdesc,
+                                norm2_update));
+
+    // Update step
+    if (stream_handle)
+        lamb_update_step<<<blocks, threads, 0,
+                      *(cudaStream_t *)stream_handle->handle>>>(
+                (float *)param_data, (const float *)update, lr, weight_decay, 
+                (float *)norm2_param, (float *)norm2_update, size);
+    else
+        lamb_update_step<<<blocks, threads>>>((float *)param_data, (const float *)update, lr, weight_decay, 
+                        (float *)norm2_param, (float *)norm2_update, size);
+
+    del_chunk(norm2_param, dev_id);
+    del_chunk(norm2_update, dev_id);
+    del_chunk(workspace, dev_id);
+    del_chunk(update, dev_id);
+    CUDNN_CALL(cudnnDestroyTensorDescriptor(adesc));
+    CUDNN_CALL(cudnnDestroyTensorDescriptor(cdesc));
+    CUDNN_CALL(cudnnDestroyReduceTensorDescriptor(rtd));
+    free(dimA);
+    free(dimC);
+    free(strideA);
+    free(strideC);
+    return 0;
+}

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -1,0 +1,303 @@
+import numpy as np
+import hetu as ht
+from hetu import gpu_links as gpu_op
+
+
+def test_adamw():
+    ctx = ht.gpu(0)
+    shape = (500,400)
+    param = np.random.uniform(-10, 10, size=shape).astype(np.float32)
+    grad = np.random.uniform(-10, 10, size=shape).astype(np.float32)
+    m = np.random.uniform(-10, 10, size=shape).astype(np.float32)
+    v = np.random.uniform(0, 10, size=shape).astype(np.float32)
+    lr = 1e-2
+    beta1 = 0.9
+    beta2 = 0.99
+    beta1t = beta1**10
+    beta2t = beta2**10
+    eps = 1e-7
+    weight_decay = 0.1
+
+    print("Prev param:")
+    print(param)
+    print("Prev m:")
+    print(m)
+    print("Prev v:")
+    print(v)
+
+    arr_param = ht.array(param, ctx)
+    arr_grad = ht.array(grad, ctx)
+    arr_m = ht.array(m, ctx)
+    arr_v = ht.array(v, ctx)
+    gpu_op.adamw_update(arr_param, arr_grad, arr_m, arr_v, lr, beta1, beta2, beta1t, beta2t, eps, weight_decay)
+    re_param = arr_param.asnumpy()
+    re_m = arr_m.asnumpy()
+    re_v = arr_v.asnumpy()
+
+    m = beta1 * m + (1 - beta1) * grad
+    v = beta2 * v + (1 - beta2) * grad * grad
+    mc = m / (1 - beta1t)
+    vc = v / (1 - beta2t)
+    update = mc / (np.sqrt(vc) + eps)
+    param = param - lr * (update + weight_decay * param)
+
+    print("Cur param:")
+    print(re_param)
+    print(param)
+
+    print("Cur m:")
+    print(re_m)
+    print(m)
+
+    print("Cur v:")
+    print(re_v)
+    print(v)
+
+    np.testing.assert_allclose(re_param, param, atol=1e-5)
+    np.testing.assert_allclose(re_m, m, atol=1e-5)
+    np.testing.assert_allclose(re_v, v, atol=1e-5)
+
+def test_lamb():
+    ctx = ht.gpu(0)
+    shape = (4,5)
+    param = np.random.uniform(-10, 10, size=shape).astype(np.float32)
+    grad = np.random.uniform(-10, 10, size=shape).astype(np.float32)
+    m = np.random.uniform(-10, 10, size=shape).astype(np.float32)
+    v = np.random.uniform(0, 10, size=shape).astype(np.float32)
+    lr = 1e-2
+    beta1 = 0.9
+    beta2 = 0.99
+    beta1t = beta1**10
+    beta2t = beta2**10
+    eps = 1e-7
+    weight_decay = 0.1
+
+    print("Prev param:")
+    print(param)
+    print("Prev m:")
+    print(m)
+    print("Prev v:")
+    print(v)
+
+    arr_param = ht.array(param, ctx)
+    arr_grad = ht.array(grad, ctx)
+    arr_m = ht.array(m, ctx)
+    arr_v = ht.array(v, ctx)
+    gpu_op.lamb_update(arr_param, arr_grad, arr_m, arr_v, lr, beta1, beta2, beta1t, beta2t, eps, weight_decay)
+    re_param = arr_param.asnumpy()
+    re_m = arr_m.asnumpy()
+    re_v = arr_v.asnumpy()
+
+    m = beta1 * m + (1 - beta1) * grad
+    v = beta2 * v + (1 - beta2) * grad * grad
+    mc = m / (1 - beta1t)
+    vc = v / (1 - beta2t)
+    update = mc / (np.sqrt(vc) + eps)
+    norm2_param = np.sqrt(np.sum(np.power(param, 2)))
+    norm2_update = np.sqrt(np.sum(np.power(update, 2)))
+    param = param - lr * norm2_param / norm2_update * (update + weight_decay * param)
+
+    print("Cur param:")
+    print(re_param)
+    print(param)
+
+    print("Cur m:")
+    print(re_m)
+    print(m)
+
+    print("Cur v:")
+    print(re_v)
+    print(v)
+
+    np.testing.assert_allclose(re_param, param, atol=1e-5)
+    np.testing.assert_allclose(re_m, m, atol=1e-5)
+    np.testing.assert_allclose(re_v, v, atol=1e-5)
+
+
+def test_adamw_sparse():
+    ctx = ht.gpu(0)
+    shape = (500, 400)
+    l = np.random.randint(0,500,size=(100))
+    indices = np.array(l)
+    param = np.random.uniform(-10, 10, size=shape).astype(np.float32)
+    grad = np.random.uniform(-10, 10, size=(indices.shape[0], shape[1])).astype(np.float32)
+    m = np.random.uniform(-10, 10, size=shape).astype(np.float32)
+    v = np.random.uniform(0, 10, size=shape).astype(np.float32)
+    lr = 1e-2
+    beta1 = 0.9
+    beta2 = 0.99
+    beta1t = beta1**10
+    beta2t = beta2**10
+    eps = 1e-7
+    weight_decay = 0.1
+
+    print("Prev param:")
+    print(param)
+    print("Prev m:")
+    print(m)
+    print("Prev v:")
+    print(v)
+    print("Indices:")
+    print(indices)
+    print("Grad:")
+    print(grad)
+
+    arr_param = ht.array(param, ctx)
+    arr_indices = ht.array(indices, ctx)
+    arr_value = ht.array(grad, ctx)
+    arr_grad = ht.IndexedSlices(indices = arr_indices, values = arr_value, dense_shape = shape)
+    arr_m = ht.array(m, ctx)
+    arr_v = ht.array(v, ctx)
+    gpu_op.adamw_update(arr_param, arr_grad, arr_m, arr_v, lr, beta1, beta2, beta1t, beta2t, eps, weight_decay)
+    re_param = arr_param.asnumpy()
+    re_m = arr_m.asnumpy()
+    re_v = arr_v.asnumpy()
+
+    # numpy deduplicate
+    d = dict()
+    for i in l:
+        d[i]=[]
+
+    for i, g in zip(l, grad):
+        d[i].append(g)
+    for key in d.keys():
+        g0 = d[key][0]
+        for i in range(1, len(d[key])):
+            g0 += d[key][i]
+        d[key] = g0
+    grad_new = []
+    l_new = []
+    for key in d.keys():
+        l_new.append(key)
+        grad_new.append(d[key])
+    grad_new = np.array(grad_new)
+
+    for idx, g in zip(l_new, grad_new):
+        m[idx] = beta1 * m[idx] + (1 - beta1) * g
+        v[idx] = beta2 * v[idx] + (1 - beta2) * g * g
+        mc_idx = m[idx] / (1 - beta1t)
+        vc_idx = v[idx] / (1 - beta2t)
+        update = mc_idx / (np.sqrt(vc_idx) + eps)
+        param[idx] = param[idx] - lr * (update + weight_decay * param[idx])
+
+    print("Cur param:")
+    print(re_param)
+    print(param)
+
+    print("Cur m:")
+    print(re_m)
+    print(m)
+
+    print("Cur v:")
+    print(re_v)
+    print(v)
+
+    np.testing.assert_allclose(re_param, param, atol=1e-5)
+    np.testing.assert_allclose(re_m, m, atol=1e-5)
+    np.testing.assert_allclose(re_v, v, atol=1e-5)
+
+
+def test_lamb_sparse():
+    ctx = ht.gpu(0)
+    shape = (500, 400)
+    l = np.random.randint(0,500,size=(100))
+    # shape = (5,4)
+    # l = [0,2,3]
+    indices = np.array(l)
+    param = np.random.uniform(-10, 10, size=shape).astype(np.float32)
+    grad = np.random.uniform(-10, 10, size=(indices.shape[0], shape[1])).astype(np.float32)
+    m = np.random.uniform(-10, 10, size=shape).astype(np.float32)
+    v = np.random.uniform(0, 10, size=shape).astype(np.float32)
+    lr = 1e-2
+    beta1 = 0.9
+    beta2 = 0.99
+    beta1t = beta1**10
+    beta2t = beta2**10
+    eps = 1e-7
+    weight_decay = 0.1
+
+    print("Prev param:")
+    print(param)
+    print("Prev m:")
+    print(m)
+    print("Prev v:")
+    print(v)
+    print("Indices:")
+    print(indices)
+    print("Grad:")
+    print(grad)
+
+    arr_param = ht.array(param, ctx)
+    arr_indices = ht.array(indices, ctx)
+    arr_value = ht.array(grad, ctx)
+    arr_grad = ht.IndexedSlices(indices = arr_indices, values = arr_value, dense_shape = shape)
+    arr_m = ht.array(m, ctx)
+    arr_v = ht.array(v, ctx)
+    gpu_op.lamb_update(arr_param, arr_grad, arr_m, arr_v, lr, beta1, beta2, beta1t, beta2t, eps, weight_decay)
+    re_param = arr_param.asnumpy()
+    re_m = arr_m.asnumpy()
+    re_v = arr_v.asnumpy()
+
+    # numpy deduplicate
+    d = dict()
+    for i in l:
+        d[i]=[]
+
+    for i, g in zip(l, grad):
+        d[i].append(g)
+    for key in d.keys():
+        g0 = d[key][0]
+        for i in range(1, len(d[key])):
+            g0 += d[key][i]
+        d[key] = g0
+    grad_new = []
+    l_new = []
+    for key in d.keys():
+        l_new.append(key)
+        grad_new.append(d[key])
+    grad_new = np.array(grad_new)
+
+    updates = []
+
+    for idx, g in zip(l_new, grad_new):
+        m[idx] = beta1 * m[idx] + (1 - beta1) * g
+        v[idx] = beta2 * v[idx] + (1 - beta2) * g * g
+        mc_idx = m[idx] / (1 - beta1t)
+        vc_idx = v[idx] / (1 - beta2t)
+        update = mc_idx / (np.sqrt(vc_idx) + eps)
+        updates.append(update)
+    updates = np.array(updates)
+
+    param_indexed = []
+    for idx in l_new:
+        param_indexed.append(param[idx])
+    param_indexed = np.array(param_indexed)
+
+    norm2_param = np.sqrt(np.sum(np.power(param_indexed, 2))) # only use indexed params to calculate norm2
+    norm2_update = np.sqrt(np.sum(np.power(updates, 2)))
+
+    #print(norm2_param, norm2_update)
+
+    for idx, u in zip(l_new, updates):
+        param[idx] = param[idx] - lr * norm2_param / norm2_update * (u + weight_decay * param[idx])
+
+    print("Cur param:")
+    print(re_param)
+    print(param)
+
+    print("Cur m:")
+    print(re_m)
+    print(m)
+
+    print("Cur v:")
+    print(re_v)
+    print(v)
+
+    np.testing.assert_allclose(re_param, param, atol=1e-5)
+    np.testing.assert_allclose(re_m, m, atol=1e-5)
+    np.testing.assert_allclose(re_v, v, atol=1e-5)
+
+test_adamw()
+test_lamb()
+test_adamw_sparse()
+test_lamb_sparse()


### PR DESCRIPTION
1.  Implement AdamW & Lamb Optimizer:
   Sparse version AdamW & Lamb only updates indexed params.
   Sparse version Lamb uses Norm2 of indexed params & updates.
2.  Optimize BERT model speed:
(1) Add CrossEntropyOp & CrossEntropySparseOp.
Use SoftmaxOp + CrossEntropySparseOp instead of a single SoftmaxCrossEntropySparseOp in BERT model to avoid recomputing in backward.
(2) Add recompute option for DropoutOp.