### PR TITLE
Operator fix and optimization

### DIFF
--- a/python/hetu/gpu_links/__init__.py
+++ b/python/hetu/gpu_links/__init__.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 from .AddConstLink import *
 from .AddElewiseLink import *
+from .Argmax import *
 from .ArraySetLink import *
 from .AvgPoolLink import *
 from .BroadcastLink import *

--- a/src/ops/Argmax.cu
+++ b/src/ops/Argmax.cu
@@ -38,7 +38,7 @@ __global__ void argmax_kernel(const float *input, float *output, size_t befor_di
 
 int DLGpuArgmax(const DLArrayHandle input, DLArrayHandle output, int dim,
                 DLStreamHandle stream_handle) {
-    assert(input->ndim == output->ndim - 1);
+    assert(input->ndim == output->ndim + 1);
     size_t befor_dim_size, reduce_dim_size, after_dim_size;
     befor_dim_size = reduce_dim_size = after_dim_size = 1;
     for (int i = 0; i < input->ndim; ++i) {

--- a/src/ops/CudnnConv2d.cu
+++ b/src/ops/CudnnConv2d.cu
@@ -1,241 +1,262 @@
-// #include "gpu_runtime.h"
+#include "gpu_runtime.h"
 
-// int CuDNN_DLGpuConv2d(const DLArrayHandle input_x, const DLArrayHandle input_f,
-//                       DLArrayHandle output, const int padding_h,
-//                       const int padding_w, const int stride_h,
-//                       const int stride_w, DLStreamHandle stream_handle = NULL) {
-//     int dev_id = (input_x->ctx).device_id;
-//     cudnn_init(dev_id, stream_handle);
-//     size_t input_N = input_x->shape[0];
-//     size_t input_C = input_x->shape[1];
-//     size_t input_H = input_x->shape[2];
-//     size_t input_W = input_x->shape[3];
-//     const float *input_data = (const float *)input_x->data;
+int CuDNN_DLGpuConv2d(const DLArrayHandle input_x, const DLArrayHandle input_f,
+                      DLArrayHandle output, const int padding_h,
+                      const int padding_w, const int stride_h,
+                      const int stride_w, DLStreamHandle stream_handle = NULL) {
+    int dev_id = (input_x->ctx).device_id;
+    cudnn_init(dev_id, stream_handle);
+    size_t input_N = input_x->shape[0];
+    size_t input_C = input_x->shape[1];
+    size_t input_H = input_x->shape[2];
+    size_t input_W = input_x->shape[3];
+    const float *input_data = (const float *)input_x->data;
 
-//     // input
-//     cudnnTensorDescriptor_t input_desc;
-//     CUDNN_CALL(cudnnCreateTensorDescriptor(&input_desc));
-//     CUDNN_CALL(cudnnSetTensor4dDescriptor(input_desc, CUDNN_TENSOR_NCHW,
-//                                           CUDNN_DATA_FLOAT, input_N, input_C,
-//                                           input_H, input_W));
-//     size_t filter_N = input_f->shape[0];
-//     size_t filter_C = input_f->shape[1];
-//     size_t filter_H = input_f->shape[2];
-//     size_t filter_W = input_f->shape[3];
-//     const float *filter_data = (const float *)input_f->data;
+    // input
+    cudnnTensorDescriptor_t input_desc;
+    CUDNN_CALL(cudnnCreateTensorDescriptor(&input_desc));
+    CUDNN_CALL(cudnnSetTensor4dDescriptor(input_desc, CUDNN_TENSOR_NCHW,
+                                          CUDNN_DATA_FLOAT, input_N, input_C,
+                                          input_H, input_W));
+    size_t filter_N = input_f->shape[0];
+    size_t filter_C = input_f->shape[1];
+    size_t filter_H = input_f->shape[2];
+    size_t filter_W = input_f->shape[3];
+    const float *filter_data = (const float *)input_f->data;
 
-//     // filter
-//     cudnnFilterDescriptor_t filter_desc;
-//     CUDNN_CALL(cudnnCreateFilterDescriptor(&filter_desc));
-//     CUDNN_CALL(cudnnSetFilter4dDescriptor(filter_desc, CUDNN_DATA_FLOAT,
-//                                           CUDNN_TENSOR_NCHW, filter_N, filter_C,
-//                                           filter_H, filter_W));
+    // filter
+    cudnnFilterDescriptor_t filter_desc;
+    CUDNN_CALL(cudnnCreateFilterDescriptor(&filter_desc));
+    CUDNN_CALL(cudnnSetFilter4dDescriptor(filter_desc, CUDNN_DATA_FLOAT,
+                                          CUDNN_TENSOR_NCHW, filter_N, filter_C,
+                                          filter_H, filter_W));
 
-//     // convolution
-//     cudnnConvolutionDescriptor_t conv_desc;
-//     CUDNN_CALL(cudnnCreateConvolutionDescriptor(&conv_desc));
-//     CUDNN_CALL(cudnnSetConvolution2dDescriptor(
-//         conv_desc, padding_h, padding_w, stride_h, stride_w, 1, 1,
-//         CUDNN_CROSS_CORRELATION, CUDNN_DATA_FLOAT));
-//     size_t out_N = output->shape[0];
-//     size_t out_C = output->shape[1];
-//     size_t out_H = output->shape[2];
-//     size_t out_W = output->shape[3];
-//     // output
-//     cudnnTensorDescriptor_t out_desc;
-//     CUDNN_CALL(cudnnCreateTensorDescriptor(&out_desc));
-//     CUDNN_CALL(cudnnSetTensor4dDescriptor(out_desc, CUDNN_TENSOR_NCHW,
-//                                           CUDNN_DATA_FLOAT, out_N, out_C, out_H,
-//                                           out_W));
-//     float *output_data = (float *)output->data;
-//     // algorithm
-//     cudnnConvolutionFwdAlgo_t algo;
-//     // algo = CUDNN_CONVOLUTION_FWD_ALGO_IMPLICIT_GEMM;
-//     // algo = CUDNN_CONVOLUTION_FWD_ALGO_WINOGRAD_NONFUSED;
-//     CUDNN_CALL(cudnnGetConvolutionForwardAlgorithm(
-//         cudnn_map[dev_id], input_desc, filter_desc, conv_desc, out_desc,
-//         CUDNN_CONVOLUTION_FWD_PREFER_FASTEST, 0, &algo));
-//     size_t workspace_size;
-//     CUDNN_CALL(cudnnGetConvolutionForwardWorkspaceSize(
-//         cudnn_map[dev_id], input_desc, filter_desc, conv_desc, out_desc, algo,
-//         &workspace_size));
+    // convolution
+    cudnnConvolutionDescriptor_t conv_desc;
+    CUDNN_CALL(cudnnCreateConvolutionDescriptor(&conv_desc));
+    CUDNN_CALL(cudnnSetConvolution2dDescriptor(
+        conv_desc, padding_h, padding_w, stride_h, stride_w, 1, 1,
+        CUDNN_CROSS_CORRELATION, CUDNN_DATA_FLOAT));
+    size_t out_N = output->shape[0];
+    size_t out_C = output->shape[1];
+    size_t out_H = output->shape[2];
+    size_t out_W = output->shape[3];
+    // output
+    cudnnTensorDescriptor_t out_desc;
+    CUDNN_CALL(cudnnCreateTensorDescriptor(&out_desc));
+    CUDNN_CALL(cudnnSetTensor4dDescriptor(out_desc, CUDNN_TENSOR_NCHW,
+                                          CUDNN_DATA_FLOAT, out_N, out_C, out_H,
+                                          out_W));
+    float *output_data = (float *)output->data;
 
-//     if (is_chunk_init(dev_id) == false) {
-//         chunk_init(dev_id);
-//     }
-//     void *work_data = find_chunk(workspace_size, dev_id);
+    // search for the best algorithm
+    int request_cnt = 9, return_cnt = 9;
+    cudnnConvolutionFwdAlgoPerf_t algo_perf[9];
+    CUDNN_CALL(cudnnGetConvolutionForwardAlgorithm_v7(
+        cudnn_map[dev_id], input_desc, filter_desc, conv_desc, out_desc,
+        request_cnt, &return_cnt, algo_perf));
+    
+    cudaError_t err;
+    size_t workspace_size;
+    void *work_data = nullptr;
+    cudnnConvolutionFwdAlgo_t algo;
+    for(int i = 0; i < return_cnt; ++i) {
+        CUDNN_CALL(cudnnGetConvolutionForwardWorkspaceSize(
+            cudnn_map[dev_id], input_desc, filter_desc, conv_desc, out_desc, algo_perf[i].algo,
+            &workspace_size));
+        err = cudaMalloc(&work_data, workspace_size);
+        if (err == cudaSuccess) {
+            algo = algo_perf[i].algo;
+            break;
+        }
+    }
 
-//     float alpha = 1.0f;
-//     float beta = 0.0f;
-//     CUDNN_CALL(cudnnConvolutionForward(
-//         cudnn_map[dev_id], &alpha, input_desc, input_data, filter_desc,
-//         filter_data, conv_desc, algo, work_data, workspace_size, &beta,
-//         out_desc, output_data));
-//     del_chunk(work_data, dev_id);
-//     CUDNN_CALL(cudnnDestroyTensorDescriptor(out_desc));
-//     CUDNN_CALL(cudnnDestroyConvolutionDescriptor(conv_desc));
-//     CUDNN_CALL(cudnnDestroyFilterDescriptor(filter_desc));
-//     CUDNN_CALL(cudnnDestroyTensorDescriptor(input_desc));
-//     return 0;
-// }
-// int CuDNN_DLGpuConv2d_Gradient_of_Filter(const DLArrayHandle input_x,
-//                                          const DLArrayHandle gradient_y,
-//                                          DLArrayHandle gradient_f,
-//                                          const int padding_h,
-//                                          const int padding_w,
-//                                          const int stride_h, const int stride_w,
-//                                          DLStreamHandle stream_handle = NULL) {
-//     // create handle
-//     int dev_id = (input_x->ctx).device_id;
-//     cudnn_init(dev_id, stream_handle);
+    float alpha = 1.0f;
+    float beta = 0.0f;
+    CUDNN_CALL(cudnnConvolutionForward(
+        cudnn_map[dev_id], &alpha, input_desc, input_data, filter_desc,
+        filter_data, conv_desc, algo, work_data, workspace_size, &beta,
+        out_desc, output_data));
 
-//     // input
-//     size_t input_N = input_x->shape[0];
-//     size_t input_C = input_x->shape[1];
-//     size_t input_H = input_x->shape[2];
-//     size_t input_W = input_x->shape[3];
-//     const float *input_data = (const float *)input_x->data;
+    cudaFree(work_data);
+    CUDNN_CALL(cudnnDestroyTensorDescriptor(out_desc));
+    CUDNN_CALL(cudnnDestroyConvolutionDescriptor(conv_desc));
+    CUDNN_CALL(cudnnDestroyFilterDescriptor(filter_desc));
+    CUDNN_CALL(cudnnDestroyTensorDescriptor(input_desc));
+    return 0;
+}
+int CuDNN_DLGpuConv2d_Gradient_of_Filter(const DLArrayHandle input_x,
+                                         const DLArrayHandle gradient_y,
+                                         DLArrayHandle gradient_f,
+                                         const int padding_h,
+                                         const int padding_w,
+                                         const int stride_h, const int stride_w,
+                                         DLStreamHandle stream_handle = NULL) {
+    // create handle
+    int dev_id = (input_x->ctx).device_id;
+    cudnn_init(dev_id, stream_handle);
 
-//     cudnnTensorDescriptor_t input_desc;
-//     CUDNN_CALL(cudnnCreateTensorDescriptor(&input_desc));
-//     CUDNN_CALL(cudnnSetTensor4dDescriptor(input_desc, CUDNN_TENSOR_NCHW,
-//                                           CUDNN_DATA_FLOAT, input_N, input_C,
-//                                           input_H, input_W));
-//     // dy
-//     size_t dy_N = gradient_y->shape[0];
-//     size_t dy_C = gradient_y->shape[1];
-//     size_t dy_H = gradient_y->shape[2];
-//     size_t dy_W = gradient_y->shape[3];
-//     const float *dy_data = (const float *)gradient_y->data;
+    // input
+    size_t input_N = input_x->shape[0];
+    size_t input_C = input_x->shape[1];
+    size_t input_H = input_x->shape[2];
+    size_t input_W = input_x->shape[3];
+    const float *input_data = (const float *)input_x->data;
 
-//     cudnnTensorDescriptor_t dy_desc;
-//     CUDNN_CALL(cudnnCreateTensorDescriptor(&dy_desc));
-//     CUDNN_CALL(cudnnSetTensor4dDescriptor(
-//         dy_desc, CUDNN_TENSOR_NCHW, CUDNN_DATA_FLOAT, dy_N, dy_C, dy_H, dy_W));
+    cudnnTensorDescriptor_t input_desc;
+    CUDNN_CALL(cudnnCreateTensorDescriptor(&input_desc));
+    CUDNN_CALL(cudnnSetTensor4dDescriptor(input_desc, CUDNN_TENSOR_NCHW,
+                                          CUDNN_DATA_FLOAT, input_N, input_C,
+                                          input_H, input_W));
+    // dy
+    size_t dy_N = gradient_y->shape[0];
+    size_t dy_C = gradient_y->shape[1];
+    size_t dy_H = gradient_y->shape[2];
+    size_t dy_W = gradient_y->shape[3];
+    const float *dy_data = (const float *)gradient_y->data;
 
-//     // conv2d
-//     cudnnConvolutionDescriptor_t conv_desc;
-//     CUDNN_CALL(cudnnCreateConvolutionDescriptor(&conv_desc));
-//     CUDNN_CALL(cudnnSetConvolution2dDescriptor(
-//         conv_desc, padding_h, padding_w, stride_h, stride_w, 1, 1,
-//         CUDNN_CROSS_CORRELATION, CUDNN_DATA_FLOAT));
-//     // dw
-//     size_t df_N = gradient_f->shape[0];
-//     size_t df_C = gradient_f->shape[1];
-//     size_t df_H = gradient_f->shape[2];
-//     size_t df_W = gradient_f->shape[3];
-//     float *df_data = (float *)gradient_f->data;
+    cudnnTensorDescriptor_t dy_desc;
+    CUDNN_CALL(cudnnCreateTensorDescriptor(&dy_desc));
+    CUDNN_CALL(cudnnSetTensor4dDescriptor(
+        dy_desc, CUDNN_TENSOR_NCHW, CUDNN_DATA_FLOAT, dy_N, dy_C, dy_H, dy_W));
 
-//     cudnnFilterDescriptor_t df_desc;
-//     CUDNN_CALL(cudnnCreateFilterDescriptor(&df_desc));
-//     CUDNN_CALL(cudnnSetFilter4dDescriptor(
-//         df_desc, CUDNN_DATA_FLOAT, CUDNN_TENSOR_NCHW, df_N, df_C, df_H, df_W));
+    // conv2d
+    cudnnConvolutionDescriptor_t conv_desc;
+    CUDNN_CALL(cudnnCreateConvolutionDescriptor(&conv_desc));
+    CUDNN_CALL(cudnnSetConvolution2dDescriptor(
+        conv_desc, padding_h, padding_w, stride_h, stride_w, 1, 1,
+        CUDNN_CROSS_CORRELATION, CUDNN_DATA_FLOAT));
+    // dw
+    size_t df_N = gradient_f->shape[0];
+    size_t df_C = gradient_f->shape[1];
+    size_t df_H = gradient_f->shape[2];
+    size_t df_W = gradient_f->shape[3];
+    float *df_data = (float *)gradient_f->data;
 
-//     // algo
-//     cudnnConvolutionBwdFilterAlgo_t algo;
-//     CUDNN_CALL(cudnnGetConvolutionBackwardFilterAlgorithm(
-//         cudnn_map[dev_id], input_desc, dy_desc, conv_desc, df_desc,
-//         CUDNN_CONVOLUTION_BWD_FILTER_PREFER_FASTEST, 0, &algo));
-//     // algo = CUDNN_CONVOLUTION_BWD_FILTER_ALGO_FFT;
-//     // algo = CUDNN_CONVOLUTION_BWD_FILTER_ALGO_0;
-//     size_t workspace_size;
-//     CUDNN_CALL(cudnnGetConvolutionBackwardFilterWorkspaceSize(
-//         cudnn_map[dev_id], input_desc, dy_desc, conv_desc, df_desc, algo,
-//         &workspace_size));
-//     if (is_chunk_init(dev_id) == false) {
-//         chunk_init(dev_id);
-//     }
-//     void *work_data = find_chunk(workspace_size, dev_id);
-//     float alpha = 1.0f;
-//     float beta = 0.0f;
-//     CUDNN_CALL(cudnnConvolutionBackwardFilter(
-//         cudnn_map[dev_id], &alpha, input_desc, input_data, dy_desc, dy_data,
-//         conv_desc, algo, work_data, workspace_size, &beta, df_desc, df_data));
-//     del_chunk(work_data, dev_id);
-//     CUDNN_CALL(cudnnDestroyTensorDescriptor(dy_desc));
-//     CUDNN_CALL(cudnnDestroyConvolutionDescriptor(conv_desc));
-//     CUDNN_CALL(cudnnDestroyFilterDescriptor(df_desc));
-//     CUDNN_CALL(cudnnDestroyTensorDescriptor(input_desc));
-//     return 0;
-// }
+    cudnnFilterDescriptor_t df_desc;
+    CUDNN_CALL(cudnnCreateFilterDescriptor(&df_desc));
+    CUDNN_CALL(cudnnSetFilter4dDescriptor(
+        df_desc, CUDNN_DATA_FLOAT, CUDNN_TENSOR_NCHW, df_N, df_C, df_H, df_W));
 
-// int CuDNN_DLGpuConv2d_Gradient_of_Data(const DLArrayHandle input_f,
-//                                        const DLArrayHandle gradient_y,
-//                                        DLArrayHandle gradient_x,
-//                                        const int padding_h, const int padding_w,
-//                                        const int stride_h, const int stride_w,
-//                                        DLStreamHandle stream_handle = NULL) {
-//     // create handle
-//     int dev_id = (input_f->ctx).device_id;
-//     cudnn_init(dev_id, stream_handle);
+    // search for the best algorithm
+    int request_cnt = 9, return_cnt = 9;
+    cudnnConvolutionBwdFilterAlgoPerf_t algo_perf[9];
+    CUDNN_CALL(cudnnGetConvolutionBackwardFilterAlgorithm_v7(
+        cudnn_map[dev_id], input_desc, dy_desc, conv_desc, df_desc,
+        request_cnt, &return_cnt, algo_perf));
 
-//     // filter
-//     size_t filter_N = input_f->shape[0];
-//     size_t filter_C = input_f->shape[1];
-//     size_t filter_H = input_f->shape[2];
-//     size_t filter_W = input_f->shape[3];
-//     const float *filter_data = (const float *)input_f->data;
+    cudaError_t err;
+    size_t workspace_size;
+    void *work_data = nullptr;
+    cudnnConvolutionBwdFilterAlgo_t algo;
+    for(int i = 0; i < return_cnt; ++i) {
+        CUDNN_CALL(cudnnGetConvolutionBackwardFilterWorkspaceSize(
+            cudnn_map[dev_id], input_desc, dy_desc, conv_desc, df_desc, algo_perf[i].algo,
+            &workspace_size));
+        err = cudaMalloc(&work_data, workspace_size);
+        if (err == cudaSuccess) {
+            algo = algo_perf[i].algo;
+            break;
+        }
+    }
 
-//     cudnnFilterDescriptor_t filter_desc;
-//     CUDNN_CALL(cudnnCreateFilterDescriptor(&filter_desc));
-//     CUDNN_CALL(cudnnSetFilter4dDescriptor(filter_desc, CUDNN_DATA_FLOAT,
-//                                           CUDNN_TENSOR_NCHW, filter_N, filter_C,
-//                                           filter_H, filter_W));
-//     // dy
-//     size_t dy_N = gradient_y->shape[0];
-//     size_t dy_C = gradient_y->shape[1];
-//     size_t dy_H = gradient_y->shape[2];
-//     size_t dy_W = gradient_y->shape[3];
-//     const float *dy_data = (const float *)gradient_y->data;
+    float alpha = 1.0f;
+    float beta = 0.0f;
+    CUDNN_CALL(cudnnConvolutionBackwardFilter(
+        cudnn_map[dev_id], &alpha, input_desc, input_data, dy_desc, dy_data,
+        conv_desc, algo, work_data, workspace_size, &beta, df_desc, df_data));
+    cudaFree(work_data);
+    CUDNN_CALL(cudnnDestroyTensorDescriptor(dy_desc));
+    CUDNN_CALL(cudnnDestroyConvolutionDescriptor(conv_desc));
+    CUDNN_CALL(cudnnDestroyFilterDescriptor(df_desc));
+    CUDNN_CALL(cudnnDestroyTensorDescriptor(input_desc));
+    return 0;
+}
 
-//     cudnnTensorDescriptor_t dy_desc;
-//     CUDNN_CALL(cudnnCreateTensorDescriptor(&dy_desc));
-//     CUDNN_CALL(cudnnSetTensor4dDescriptor(
-//         dy_desc, CUDNN_TENSOR_NCHW, CUDNN_DATA_FLOAT, dy_N, dy_C, dy_H, dy_W));
+int CuDNN_DLGpuConv2d_Gradient_of_Data(const DLArrayHandle input_f,
+                                       const DLArrayHandle gradient_y,
+                                       DLArrayHandle gradient_x,
+                                       const int padding_h, const int padding_w,
+                                       const int stride_h, const int stride_w,
+                                       DLStreamHandle stream_handle = NULL) {
+    // create handle
+    int dev_id = (input_f->ctx).device_id;
+    cudnn_init(dev_id, stream_handle);
 
-//     // conv2d
-//     cudnnConvolutionDescriptor_t conv_desc;
-//     CUDNN_CALL(cudnnCreateConvolutionDescriptor(&conv_desc));
-//     CUDNN_CALL(cudnnSetConvolution2dDescriptor(
-//         conv_desc, padding_h, padding_w, stride_h, stride_w, 1, 1,
-//         CUDNN_CROSS_CORRELATION, CUDNN_DATA_FLOAT));
-//     // dx
-//     size_t dx_N = gradient_x->shape[0];
-//     size_t dx_C = gradient_x->shape[1];
-//     size_t dx_H = gradient_x->shape[2];
-//     size_t dx_W = gradient_x->shape[3];
-//     float *dx_data = (float *)gradient_x->data;
+    // filter
+    size_t filter_N = input_f->shape[0];
+    size_t filter_C = input_f->shape[1];
+    size_t filter_H = input_f->shape[2];
+    size_t filter_W = input_f->shape[3];
+    const float *filter_data = (const float *)input_f->data;
 
-//     cudnnTensorDescriptor_t dx_desc;
-//     CUDNN_CALL(cudnnCreateTensorDescriptor(&dx_desc));
-//     CUDNN_CALL(cudnnSetTensor4dDescriptor(
-//         dx_desc, CUDNN_TENSOR_NCHW, CUDNN_DATA_FLOAT, dx_N, dx_C, dx_H, dx_W));
+    cudnnFilterDescriptor_t filter_desc;
+    CUDNN_CALL(cudnnCreateFilterDescriptor(&filter_desc));
+    CUDNN_CALL(cudnnSetFilter4dDescriptor(filter_desc, CUDNN_DATA_FLOAT,
+                                          CUDNN_TENSOR_NCHW, filter_N, filter_C,
+                                          filter_H, filter_W));
+    // dy
+    size_t dy_N = gradient_y->shape[0];
+    size_t dy_C = gradient_y->shape[1];
+    size_t dy_H = gradient_y->shape[2];
+    size_t dy_W = gradient_y->shape[3];
+    const float *dy_data = (const float *)gradient_y->data;
 
-//     // algo
-//     cudnnConvolutionBwdDataAlgo_t algo;
-//     CUDNN_CALL(cudnnGetConvolutionBackwardDataAlgorithm(
-//         cudnn_map[dev_id], filter_desc, dy_desc, conv_desc, dx_desc,
-//         CUDNN_CONVOLUTION_BWD_DATA_PREFER_FASTEST, 0, &algo));
-//     // algo = CUDNN_CONVOLUTION_BWD_DATA_ALGO_0;
-//     // algo = CUDNN_CONVOLUTION_BWD_DATA_ALGO_WINOGRAD_NONFUSED;
-//     size_t workspace_size;
-//     CUDNN_CALL(cudnnGetConvolutionBackwardDataWorkspaceSize(
-//         cudnn_map[dev_id], filter_desc, dy_desc, conv_desc, dx_desc, algo,
-//         &workspace_size));
-//     if (is_chunk_init(dev_id) == false) {
-//         chunk_init(dev_id);
-//     }
-//     void *work_data = find_chunk(workspace_size, dev_id);
+    cudnnTensorDescriptor_t dy_desc;
+    CUDNN_CALL(cudnnCreateTensorDescriptor(&dy_desc));
+    CUDNN_CALL(cudnnSetTensor4dDescriptor(
+        dy_desc, CUDNN_TENSOR_NCHW, CUDNN_DATA_FLOAT, dy_N, dy_C, dy_H, dy_W));
 
-//     float alpha = 1.0f;
-//     float beta = 0.0f;
-//     CUDNN_CALL(cudnnConvolutionBackwardData(
-//         cudnn_map[dev_id], &alpha, filter_desc, filter_data, dy_desc, dy_data,
-//         conv_desc, algo, work_data, workspace_size, &beta, dx_desc, dx_data));
-//     del_chunk(work_data, dev_id);
-//     CUDNN_CALL(cudnnDestroyTensorDescriptor(dy_desc));
-//     CUDNN_CALL(cudnnDestroyConvolutionDescriptor(conv_desc));
-//     CUDNN_CALL(cudnnDestroyTensorDescriptor(dx_desc));
-//     CUDNN_CALL(cudnnDestroyFilterDescriptor(filter_desc));
-//     return 0;
-// }
+    // conv2d
+    cudnnConvolutionDescriptor_t conv_desc;
+    CUDNN_CALL(cudnnCreateConvolutionDescriptor(&conv_desc));
+    CUDNN_CALL(cudnnSetConvolution2dDescriptor(
+        conv_desc, padding_h, padding_w, stride_h, stride_w, 1, 1,
+        CUDNN_CROSS_CORRELATION, CUDNN_DATA_FLOAT));
+
+    // dx
+    size_t dx_N = gradient_x->shape[0];
+    size_t dx_C = gradient_x->shape[1];
+    size_t dx_H = gradient_x->shape[2];
+    size_t dx_W = gradient_x->shape[3];
+    float *dx_data = (float *)gradient_x->data;
+
+    cudnnTensorDescriptor_t dx_desc;
+    CUDNN_CALL(cudnnCreateTensorDescriptor(&dx_desc));
+    CUDNN_CALL(cudnnSetTensor4dDescriptor(
+        dx_desc, CUDNN_TENSOR_NCHW, CUDNN_DATA_FLOAT, dx_N, dx_C, dx_H, dx_W));
+
+    // search for the best algorithm
+    int request_cnt = 9, return_cnt = 9;
+    cudnnConvolutionBwdDataAlgoPerf_t algo_perf[9];
+    CUDNN_CALL(cudnnGetConvolutionBackwardDataAlgorithm_v7(
+        cudnn_map[dev_id], filter_desc, dy_desc, conv_desc, dx_desc,
+        request_cnt, &return_cnt, algo_perf));
+
+    cudaError_t err;
+    size_t workspace_size;
+    void *work_data = nullptr;
+    cudnnConvolutionBwdDataAlgo_t algo;
+    for(int i = 0; i < return_cnt; ++i) {
+        CUDNN_CALL(cudnnGetConvolutionBackwardDataWorkspaceSize(
+            cudnn_map[dev_id], filter_desc, dy_desc, conv_desc, dx_desc, algo_perf[i].algo,
+            &workspace_size));
+        err = cudaMalloc(&work_data, workspace_size);
+        if (err == cudaSuccess) {
+            algo = algo_perf[i].algo;
+            break;
+        }
+    }
+
+    float alpha = 1.0f;
+    float beta = 0.0f;
+    CUDNN_CALL(cudnnConvolutionBackwardData(
+        cudnn_map[dev_id], &alpha, filter_desc, filter_data, dy_desc, dy_data,
+        conv_desc, algo, work_data, workspace_size, &beta, dx_desc, dx_data));
+    cudaFree(work_data);
+    CUDNN_CALL(cudnnDestroyTensorDescriptor(dy_desc));
+    CUDNN_CALL(cudnnDestroyConvolutionDescriptor(conv_desc));
+    CUDNN_CALL(cudnnDestroyTensorDescriptor(dx_desc));
+    CUDNN_CALL(cudnnDestroyFilterDescriptor(filter_desc));
+    return 0;
+}

--- a/src/ops/Gelu.cu
+++ b/src/ops/Gelu.cu
@@ -1,12 +1,13 @@
 #include "gpu_runtime.h"
-#define pi 3.14159265358979323846
-#define e  2.71828182845904523536
+#define pi 3.14159265358979323846f
+#define e  2.71828182845904523536f
+#define SQRT_1_2  0.70710678118654757274f  // sqrt(1/2)
 
 __global__ void Gelu_kernel(float *input, float *output, size_t size) {
     size_t ind = blockIdx.x * blockDim.x + threadIdx.x;
     if (ind >= size)
         return;
-    output[ind] = input[ind] * 0.5 * (1.0 + erf( input[ind]/sqrt(2.0)));
+    output[ind] = input[ind] * 0.5f * (1.0f + erff(input[ind] * SQRT_1_2));
 }
 
 int DLGpuGelu(const DLArrayHandle input, DLArrayHandle output,
@@ -40,7 +41,7 @@ __global__ void gelu_grad_kernel(const float *input, const float *in_grad,
     size_t ind = blockIdx.x * blockDim.x + threadIdx.x;
     if (ind >= size)
         return;
-    output[ind] = in_grad[ind]*(0.5+0.5*erf( input[ind]/sqrt(2.0))+0.5*input[ind]*(sqrt(2.0)*pow(e,(-0.5*pow(input[ind],2)))/sqrt(pi)));
+    output[ind] = in_grad[ind]*(0.5f+0.5f*erf( input[ind]/sqrtf(2.0))+0.5f*input[ind]*(sqrtf(2.0f)*powf(e,(-0.5f*powf(input[ind],2.0f)))/sqrtf(pi)));
 }
 
 int DLGpuGeluGradient(const DLArrayHandle input, const DLArrayHandle in_grad,

--- a/src/ops/LayerNorm.cu
+++ b/src/ops/LayerNorm.cu
@@ -1,27 +1,64 @@
 #include "gpu_runtime.h"
 
-__global__ void minus_mean_n_square_kernel(const float *in_arr,
-                                           const float *mean, float *out_arr,
-                                           int last_dim, size_t size) {
-    size_t ind = blockIdx.x * blockDim.x + threadIdx.x;
-    if (ind >= size)
-        return;
-    float temp = in_arr[ind] - mean[ind / last_dim];
-    out_arr[ind] = temp * temp;
+__forceinline__ __device__ float WarpReduceSum(float val) {
+  unsigned int mask = __ballot_sync(0xFFFFFFFF, true);
+  for (unsigned int k = (warpSize >> 1); k > 0; k >>= 1)
+    val += __shfl_down_sync(mask, val, k, warpSize);
+  return val;
 }
 
-__global__ void rescale_kernel(const float *in_arr, const float *mean_arr,
-                               const float *var_arr, const float *ln_scale,
-                               const float *ln_bias, float *out_arr,
-                               int last_dim, float eps, size_t size) {
-    size_t ind = blockIdx.x * blockDim.x + threadIdx.x;
-    if (ind >= size)
-        return;
-    size_t mo_ind = ind / last_dim;
-    size_t ln_ind = ind % last_dim;
-    out_arr[ind] = (in_arr[ind] - mean_arr[mo_ind])
-                       / sqrtf(var_arr[mo_ind] + eps) * ln_scale[ln_ind]
-                   + ln_bias[ln_ind];
+__forceinline__ __device__ void BlockReduceSum(float &val, float *shared) {
+    int tid = threadIdx.x % warpSize;
+    int wid = threadIdx.x / warpSize;
+
+    val = WarpReduceSum(val);
+
+    __syncthreads();
+    if (tid == 0)
+        shared[wid] = val;
+
+    __syncthreads();
+    val = (threadIdx.x < blockDim.x / warpSize) ? shared[tid] : 0;
+
+    if (wid == 0)
+        val = WarpReduceSum(val);
+}
+
+__global__ void layer_norm_forward(const float *x,
+                                   const float *scale,
+                                   const float *bias,
+                                   float* y,
+                                   float *mean, float *var,
+                                   const float eps, const int C) {
+    __shared__ float var_share;
+    __shared__ float mean_share;
+    __shared__ float shared_var[32];
+    __shared__ float shared_mean[32];
+
+    int begin = blockIdx.x * C + threadIdx.x;
+    int end = (blockIdx.x + 1) * C;
+
+    float mean_thread = 0, var_thread = 0;
+    for (int i = begin; i < end; i += blockDim.x) {
+        mean_thread += x[i];
+        var_thread += (x[i] * x[i]);
+    }
+
+    BlockReduceSum(mean_thread, shared_mean);
+    BlockReduceSum(var_thread, shared_var);
+    if (threadIdx.x == 0) {
+        mean[blockIdx.x] = mean_share = mean_thread / C;
+        var_share = var_thread / C - mean_share * mean_share;
+        if (var_share < 0) var_share = 0;
+        var[blockIdx.x] = var_share;
+    }
+    __syncthreads();
+
+    mean_thread = mean_share;
+    var_thread = var_share;
+    float tmp = 1.0f / sqrtf(var_thread + eps);
+    for (int i = begin, j = threadIdx.x; i < end; i += blockDim.x, j += blockDim.x)
+        y[i] = (x[i] - mean_thread) * tmp * scale[j] + bias[j];
 }
 
 int DLGpuLayerNormalization(const DLArrayHandle in_arr,
@@ -29,110 +66,22 @@ int DLGpuLayerNormalization(const DLArrayHandle in_arr,
                             const DLArrayHandle ln_bias, DLArrayHandle mean_arr,
                             DLArrayHandle var_arr, DLArrayHandle out_arr,
                             float eps, DLStreamHandle stream_handle) {
-    int dev_id = (in_arr->ctx).device_id;
-    cudaSetDevice(dev_id);
-    cudnn_init(dev_id, stream_handle);
-
-    float one = 1.0f;
-    float zero = 0.0f;
-
-    cudnnReduceTensorDescriptor_t rtd;
-    CUDNN_CALL(cudnnCreateReduceTensorDescriptor(&rtd));
-    CUDNN_CALL(cudnnSetReduceTensorDescriptor(
-        rtd, CUDNN_REDUCE_TENSOR_AVG, CUDNN_DATA_FLOAT, CUDNN_PROPAGATE_NAN,
-        CUDNN_REDUCE_TENSOR_NO_INDICES, CUDNN_32BIT_INDICES));
-
-    cudnnTensorDescriptor_t adesc;
-    cudnnTensorDescriptor_t cdesc;
-    CUDNN_CALL(cudnnCreateTensorDescriptor(&adesc));
-    CUDNN_CALL(cudnnCreateTensorDescriptor(&cdesc));
-
     int ndim = in_arr->ndim;
-    int last_dim = in_arr->shape[ndim - 1];
-    if (ndim < 4)
-        ndim = 4;
-    size_t cpu_mem = ndim * sizeof(int);
-    int *dimA = (int *)malloc(cpu_mem);
-    int *strideA = (int *)malloc(cpu_mem);
-    int *dimC = (int *)malloc(cpu_mem);
-    int *strideC = (int *)malloc(cpu_mem);
-
-    int temp_strideA = 1;
-    int temp_strideC = 1;
-
-    for (int i = ndim - 1; i >= 0; --i) {
-        dimA[i] = i < in_arr->ndim ? (int)in_arr->shape[i] : 1;
-        dimC[i] = i < in_arr->ndim - 1 ? (int)in_arr->shape[i] : 1;
-        strideA[i] = temp_strideA;
-        strideC[i] = temp_strideC;
-        temp_strideA *= dimA[i];
-        temp_strideC *= dimC[i];
-    }
-    size_t size = temp_strideA * sizeof(float);
-
-    CUDNN_CALL(cudnnSetTensorNdDescriptor(adesc, CUDNN_DATA_FLOAT, ndim, dimA,
-                                          strideA));
-    CUDNN_CALL(cudnnSetTensorNdDescriptor(cdesc, CUDNN_DATA_FLOAT, ndim, dimC,
-                                          strideC));
-
-    CUDNN_CALL(cudnnReduceTensor(cudnn_map[dev_id], rtd, NULL, 0,
-                                 (void *)out_arr->data, size, &one, adesc,
-                                 (const void *)in_arr->data, &zero, cdesc,
-                                 (void *)mean_arr->data));
-
-    dim3 blocks;
-    dim3 threads;
-    if (temp_strideA <= 1024) {
-        threads.x = temp_strideA;
-        blocks.x = 1;
-    } else {
-        threads.x = 1024;
-        blocks.x = (temp_strideA + 1023) / 1024;
-    }
+    int B = 1, C = in_arr->shape[ndim - 1];
+    for(int i = 0; i < ndim - 1; ++i)
+        B *= in_arr->shape[i];
+    int BlockDim = (C >= 1024 ? 1024: 64);
 
     if (stream_handle)
-        minus_mean_n_square_kernel<<<blocks, threads, 0,
-                                     *(cudaStream_t *)stream_handle->handle>>>(
-            (const float *)in_arr->data, (const float *)mean_arr->data,
-            (float *)out_arr->data, last_dim, temp_strideA);
+        layer_norm_forward<<<B, BlockDim, 0, *(cudaStream_t *)stream_handle->handle>>>(
+                (const float *)in_arr->data, (const float *)ln_scale->data,
+                (const float *)ln_bias->data, (float *)out_arr->data,
+                (float *)mean_arr->data, (float *)var_arr->data, eps, C);
     else
-        minus_mean_n_square_kernel<<<blocks, threads>>>(
-            (const float *)in_arr->data, (const float *)mean_arr->data,
-            (float *)out_arr->data, last_dim, temp_strideA);
-
-    CUDNN_CALL(cudnnReduceTensor(cudnn_map[dev_id], rtd, NULL, 0,
-                                 (void *)out_arr->data, size, &one, adesc,
-                                 (const void *)out_arr->data, &zero, cdesc,
-                                 (void *)var_arr->data));
-
-    if (temp_strideA <= 1024) {
-        threads.x = temp_strideA;
-        blocks.x = 1;
-    } else {
-        threads.x = 1024;
-        blocks.x = (temp_strideA + 1023) / 1024;
-    }
-    if (stream_handle)
-        rescale_kernel<<<blocks, threads, 0,
-                         *(cudaStream_t *)stream_handle->handle>>>(
-            (const float *)in_arr->data, (const float *)mean_arr->data,
-            (const float *)var_arr->data, (const float *)ln_scale->data,
-            (const float *)ln_bias->data, (float *)out_arr->data, last_dim, eps,
-            temp_strideA);
-    else
-        rescale_kernel<<<blocks, threads>>>(
-            (const float *)in_arr->data, (const float *)mean_arr->data,
-            (const float *)var_arr->data, (const float *)ln_scale->data,
-            (const float *)ln_bias->data, (float *)out_arr->data, last_dim, eps,
-            temp_strideA);
-
-    CUDNN_CALL(cudnnDestroyTensorDescriptor(adesc));
-    CUDNN_CALL(cudnnDestroyTensorDescriptor(cdesc));
-    CUDNN_CALL(cudnnDestroyReduceTensorDescriptor(rtd));
-    free(dimA);
-    free(dimC);
-    free(strideA);
-    free(strideC);
+        layer_norm_forward<<<B, BlockDim, 0>>>(
+                (const float *)in_arr->data, (const float *)ln_scale->data,
+                (const float *)ln_bias->data, (float *)out_arr->data,
+                (float *)mean_arr->data, (float *)var_arr->data, eps, C);
     return 0;
 }
 

--- a/src/ops/Sigmoid.cu
+++ b/src/ops/Sigmoid.cu
@@ -4,7 +4,7 @@ __global__ void sigmoid_kernel(float *input, float *output, size_t size) {
     size_t ind = blockIdx.x * blockDim.x + threadIdx.x;
     if (ind >= size)
         return;
-    output[ind] = 1.0 / (1.0 + 1.0 / exp(input[ind]));
+    output[ind] = 1.0f / (1.0f + exp(-input[ind]));
 }
 
 int DLGpuSigmoid(const DLArrayHandle input, DLArrayHandle output,

--- a/tests/test_gpu_op.py
+++ b/tests/test_gpu_op.py
@@ -1451,6 +1451,34 @@ def test_onehot():
     print(arr_y.asnumpy())
 
 
+def test_gelu():
+    shape = (2000, 2500)
+    ctx = ht.gpu(0)
+    x = np.random.uniform(-1, 1, shape).astype(np.float32)
+    arr_x = ht.array(x, ctx=ctx)
+    arr_y = ht.empty(shape, ctx=ctx)
+    gpu_op.gelu(arr_x, arr_y)
+    y = arr_y.asnumpy()
+    import torch
+    import torch.nn.functional as F
+    ans = F.gelu(torch.Tensor(x)).numpy()
+    np.testing.assert_allclose(ans, y, rtol=1e-5)
+
+
+def test_sigmoid():
+    shape = (2000, 2500)
+    ctx = ht.gpu(0)
+    x = np.random.uniform(-1, 1, shape).astype(np.float32)
+    arr_x = ht.array(x, ctx=ctx)
+    arr_y = ht.empty(shape, ctx=ctx)
+    gpu_op.sigmoid(arr_x, arr_y)
+    y = arr_y.asnumpy()
+    import torch
+    import torch.nn.functional as F
+    ans = torch.sigmoid(torch.Tensor(x)).numpy()
+    np.testing.assert_allclose(ans, y, rtol=1e-6)
+
+
 test_array_set()
 test_broadcast_to()
 test_reduce_sum_axis_zero()
@@ -1496,3 +1524,5 @@ test_dropout2d()
 test_instance_norm2d()
 test_instance_norm2d_gradient()
 test_onehot()
+test_gelu()
+test_sigmoid()

--- a/tests/test_ops_speed.py
+++ b/tests/test_ops_speed.py
@@ -1,0 +1,358 @@
+import time
+import random
+import numpy as np
+import hetu as ht
+from hetu import gpu_links as gpu_opl
+from hetu import gpu_ops as gpu_op
+from hetu.stream import create_stream_handle
+from hetu.gpu_links.Argmax import argmax
+
+
+def test_common(op, num_args, input_shapes, has_const=False, need_output=True, *args):
+    ctx = ht.gpu(0)
+    stream = create_stream_handle(ctx)
+    TOTAL_ROUNDS = 5
+    for shape in input_shapes:
+        total_time = 0
+        input_vals = [ht.array(np.random.normal(size=shape), ctx=ctx) for _ in range(num_args)]
+        if has_const:
+            input_vals.append(random.randint(-1000, 1000))
+        if need_output:
+            output = ht.array(np.random.normal(size=shape), ctx=ctx)
+        for i in range(TOTAL_ROUNDS):
+            start = time.time()
+            if need_output:
+                op(*input_vals, output, *args, stream=stream)
+            else:
+                op(*input_vals, *args, stream=stream)
+            stream.sync()
+            if i > 0:
+                total_time += time.time() - start
+
+        total_time *= 1000 / (TOTAL_ROUNDS - 1)
+        print('Op %s test with shape: %s takes %fms' %
+            (op, shape, total_time))
+
+
+def test_pooling(op, num_args, input_shapes, kernel_H, kernel_W, padding=0, stride=1, has_const=False, need_output=True):
+    ctx = ht.gpu(0)
+    stream = create_stream_handle(ctx)
+    TOTAL_ROUNDS = 5
+    for shape in input_shapes:
+        total_time = 0
+        input_vals = [ht.array(np.random.normal(size=shape), ctx=ctx) for _ in range(num_args)]
+        if has_const:
+            input_vals.append(random.randint(-1000, 1000))
+        if need_output:
+            output = ht.array(np.random.normal(size=shape), ctx=ctx)
+        for i in range(TOTAL_ROUNDS):
+            start = time.time()
+            if need_output:
+                op(*input_vals, kernel_H, kernel_W, output, padding, stride, stream=stream)
+            else:
+                op(*input_vals, kernel_H, kernel_W, padding, stride, stream=stream)
+            stream.sync()
+            if i > 0:
+                total_time += time.time() - start
+
+        total_time *= 1000 / (TOTAL_ROUNDS - 1)
+        print('Op %s test with shape: %s takes %fms' %
+            (op, shape, total_time))
+
+
+def test_argmax(shapes):
+    ctx = ht.gpu(0)
+    stream = create_stream_handle(ctx)
+    TOTAL_ROUNDS = 5
+    for shape in shapes:
+        total_time = 0
+        input_val = ht.array(np.random.normal(size=shape), ctx=ctx)
+        output = ht.array(np.random.normal(size=(shape[0], shape[1])), ctx=ctx)
+        for i in range(TOTAL_ROUNDS):
+            start = time.time()
+            gpu_opl.argmax(input_val, output, dim=2, stream=stream)
+            stream.sync()
+            if i > 0:
+                total_time += time.time() - start
+
+        total_time *= 1000 / (TOTAL_ROUNDS - 1)
+        print('Op %s test with shape: %s takes %fms' %
+            ('argmax', shape, total_time))
+
+
+def test_concat(shapes):
+    ctx = ht.gpu(0)
+    stream = create_stream_handle(ctx)
+    TOTAL_ROUNDS = 5
+    for shape in shapes:
+        total_time = 0
+        input_a = ht.array(np.random.normal(size=shape), ctx=ctx)
+        input_b = ht.array(np.random.normal(size=shape), ctx=ctx)
+        output = ht.array(np.random.normal(size=(shape[0], shape[1], shape[2]*2)), ctx=ctx)
+        for i in range(TOTAL_ROUNDS):
+            start = time.time()
+            gpu_opl.concat(input_a, input_b, output, axis=2, stream=stream)
+            stream.sync()
+            if i > 0:
+                total_time += time.time() - start
+
+        total_time *= 1000 / (TOTAL_ROUNDS - 1)
+        print('Op %s test with shape: %s takes %fms' %
+            ('concat', shape, total_time))
+
+
+def test_matmul(shapes):
+    ctx = ht.gpu(0)
+    stream = create_stream_handle(ctx)
+    TOTAL_ROUNDS = 5
+    for shape in shapes:
+        total_time = 0
+        input_vals = [ht.array(np.random.normal(size=shape), ctx=ctx) for _ in range(2)]
+        output = ht.array(np.random.normal(size=shape), ctx=ctx)
+        for i in range(TOTAL_ROUNDS):
+            start = time.time()
+            gpu_opl.batch_matrix_multiply(input_vals[0], False, input_vals[1], True, output, stream=stream)
+            stream.sync()
+            if i > 0:
+                total_time += time.time() - start
+
+        total_time *= 1000 / (TOTAL_ROUNDS - 1)
+        print('Op %s test with shape: %s takes %fms' %
+            ('matmul', shape, total_time))
+
+
+def test_broadcast_to(shapes):
+    ctx = ht.gpu(0)
+    stream = create_stream_handle(ctx)
+    TOTAL_ROUNDS = 5
+    for shape in shapes:
+        total_time = 0
+        input_vals = [ht.array(np.random.normal(size=(shape[1], shape[2])), ctx=ctx) for _ in range(2)]
+        output = ht.array(np.random.normal(size=shape), ctx=ctx)
+        for i in range(TOTAL_ROUNDS):
+            start = time.time()
+            gpu_opl.broadcast_to(input_vals[0], output, stream=stream)
+            stream.sync()
+            if i > 0:
+                total_time += time.time() - start
+
+        total_time *= 1000 / (TOTAL_ROUNDS - 1)
+        print('Op %s test with shape: %s takes %fms' %
+            ('broadcast_to', shape, total_time))
+
+
+def test_conv2d(shapes):
+    ctx = ht.gpu(0)
+    stream = create_stream_handle(ctx)
+    TOTAL_ROUNDS = 5
+    for shape in shapes:
+        shapeX = shape
+        shapeF = (shape[1]*2, shape[1], 3, 3)
+        shapeY = (shape[0], shape[1]*2, shape[2], shape[3])
+        x = np.random.uniform(0, 1, size=shapeX).astype(np.float32)
+        f = np.random.uniform(0, 1, size=shapeF).astype(np.float32)
+        arr_x = ht.array(x, ctx=ctx)
+        arr_f = ht.array(f, ctx=ctx)
+        arr_y = ht.empty(shapeY, ctx=ctx)
+        total_time = 0
+        for i in range(TOTAL_ROUNDS):
+            start = time.time()
+            gpu_opl.CuDNN_conv2d(arr_x, arr_f, arr_y, (1, 1), (1, 1), stream=stream)
+            stream.sync()
+            if i > 0:
+                total_time += time.time() - start
+
+        total_time *= 1000 / (TOTAL_ROUNDS - 1)
+        print('Op %s test with shape: %s takes %fms' %
+            ('conv2d', shape, total_time))
+
+
+def test_reduce_sum(shapes, axes):
+    ctx = ht.gpu(0)
+    stream = create_stream_handle(ctx)
+    TOTAL_ROUNDS = 2
+    for shape in shapes:
+        input = ht.Variable(name='input', ctx=ctx)
+        conv = gpu_op.reduce_sum_op(input, axes, ctx=ctx)
+        executor = ht.Executor([conv], ctx=ctx)
+        total_time = 0
+        for i in range(TOTAL_ROUNDS):
+            x = ht.array(np.random.uniform(-1, 1, size=shape).astype(np.float32), ctx=ctx)
+            start = time.time()
+            executor.run(feed_dict={input: x})
+            stream.sync()
+            if i > 0:
+                total_time += time.time() - start
+
+        total_time *= 1000 / (TOTAL_ROUNDS - 1)
+        print('Op %s test with shape: %s takes %fms' %
+            ('reduce_sum', shape, total_time))
+
+
+def test_dropout(shapes):
+    ctx = ht.gpu(0)
+    stream = create_stream_handle(ctx)
+    TOTAL_ROUNDS = 2
+    for shape in shapes:
+        input = ht.Variable(name='dropout_input', ctx=ctx)
+        dropout_op = gpu_op.dropout_op(input, 0.3, inplace=True, ctx=ctx)
+        executor = ht.Executor([dropout_op], ctx=ctx)
+        total_time = 0
+        for i in range(TOTAL_ROUNDS):
+            x = ht.array(np.random.uniform(-1, 1, size=shape).astype(np.float32), ctx=ctx)
+            start = time.time()
+            executor.run(feed_dict={input: x})
+            stream.sync()
+            if i > 0:
+                total_time += time.time() - start
+
+        total_time *= 1000 / (TOTAL_ROUNDS - 1)
+        print('Op %s test with shape: %s takes %fms' %
+            ('dropout', shape, total_time))
+
+
+def test_layernorm(shapes):
+    ctx = ht.gpu(0)
+    stream = create_stream_handle(ctx)
+    TOTAL_ROUNDS = 5
+    for shape in shapes:
+        input = ht.Variable(name='layer_norm_input', ctx=ctx)
+        scale = ht.init.ones(name='layer_norm_scale', shape=(shape[-1], ), ctx=ctx)
+        bias = ht.init.zeros(name='layer_norm_biad', shape=(shape[-1], ), ctx=ctx)
+        layernorm = gpu_op.layer_normalization_op(input, scale, bias, ctx=ctx)
+        executor = ht.Executor([layernorm], ctx=ctx)
+        total_time = 0
+        for i in range(TOTAL_ROUNDS):
+            x = ht.array(np.random.uniform(-1, 1, size=shape).astype(np.float32), ctx=ctx)
+            start = time.time()
+            ret = executor.run(feed_dict={input: x})
+            stream.sync()
+            if i > 0:
+                total_time += time.time() - start
+
+        total_time *= 1000 / (TOTAL_ROUNDS - 1)
+        print('Op %s test with shape: %s takes %fms' %
+            ('layernorm', shape, total_time))
+
+
+def test_cross_entropy(shapes):
+    ctx = ht.gpu(0)
+    stream = create_stream_handle(ctx)
+    TOTAL_ROUNDS = 2
+    for shape in shapes:
+        arr_x = ht.array(np.random.uniform(-1, 1, size=shape).astype(np.float32), ctx=ctx)
+        arr_y = ht.array(np.random.randint(0, shape[1], size=(shape[0], 1)).astype(np.int32), ctx=ctx)
+        out = ht.array(np.random.uniform(-1, 1, size=(shape[0])), ctx=ctx)
+        total_time = 0
+        for i in range(TOTAL_ROUNDS):
+            start = time.time()
+            gpu_opl.cross_entropy(arr_x, arr_y, out, stream=stream)
+            stream.sync()
+            if i > 0:
+                total_time += time.time() - start
+
+        total_time *= 1000 / (TOTAL_ROUNDS - 1)
+        print('Op %s test with shape: %s takes %fms' %
+            ('cross_entropy', shape, total_time))
+
+
+def test_linear(shapes):
+    ctx = ht.gpu(0)
+    stream = create_stream_handle(ctx)
+    TOTAL_ROUNDS = 5
+    for shape in shapes:
+        nodeA = ht.Variable(name='linear_node_A', ctx=ctx)
+        nodeB = ht.Variable(name='linear_node_B', ctx=ctx)
+        bias = ht.Variable(name='linear_bias', ctx=ctx)
+        linear = gpu_op.linear_op(nodeA, nodeB, bias, ctx=ctx)
+        executor = ht.Executor([linear], ctx=ctx)
+        total_time = 0
+        for i in range(TOTAL_ROUNDS):
+            x = ht.array(np.random.uniform(-1, 1, size=shape).astype(np.float32), ctx=ctx)
+            y = ht.array(np.random.uniform(-1, 1, size=(shape[1], shape[1]*2)).astype(np.float32), ctx=ctx)
+            b = ht.array(np.random.uniform(-1, 1, size=(shape[1]*2)).astype(np.float32), ctx=ctx)
+            start = time.time()
+            executor.run(feed_dict={nodeA: x, nodeB: y, bias: b})
+            stream.sync()
+            if i > 0:
+                total_time += time.time() - start
+
+        total_time *= 1000 / (TOTAL_ROUNDS - 1)
+        print('Op %s test with shape: %s takes %fms' %
+            ('linear', shape, total_time))
+
+
+def test_slice(shapes, slices):
+    ctx = ht.gpu(0)
+    stream = create_stream_handle(ctx)
+    TOTAL_ROUNDS = 5
+    for shape in shapes:
+        total_time = 0
+        input = ht.array(np.random.normal(size=shape), ctx=ctx)
+        output_shape = []
+        for dim, slice in zip(shape, slices):
+            output_shape.append(dim - slice)
+        output = ht.array(np.random.normal(size=output_shape), ctx=ctx)
+        for i in range(TOTAL_ROUNDS):
+            start = time.time()
+            gpu_opl.matrix_slice(input, output, slices, stream=stream)
+            stream.sync()
+            if i > 0:
+                total_time += time.time() - start
+
+        total_time *= 1000 / (TOTAL_ROUNDS - 1)
+        print('Op %s test with shape: %s takes %fms' %
+            ('slice', shape, total_time))
+
+
+def test_transpose(shapes, perm):
+    ctx = ht.gpu(0)
+    stream = create_stream_handle(ctx)
+    TOTAL_ROUNDS = 5
+    for shape in shapes:
+        total_time = 0
+        input = ht.array(np.random.normal(size=shape), ctx=ctx)
+        output_shape = []
+        for i in range(len(shape)):
+            output_shape.append(shape[i])
+        output = ht.array(np.random.normal(size=output_shape), ctx=ctx)
+        for i in range(TOTAL_ROUNDS):
+            start = time.time()
+            gpu_opl.matrix_transpose(input, output, perm, stream=stream)
+            stream.sync()
+            if i > 0:
+                total_time += time.time() - start
+
+        total_time *= 1000 / (TOTAL_ROUNDS - 1)
+        print('Op %s test with shape: %s takes %fms' %
+            ('transpose', shape, total_time))
+
+
+shapes = [(64, 1024, 392), (256, 1024, 392), (1024, 1024, 392), (1024, 1024, 784)]
+shapes_conv = [(64, 392, 32, 32), (256, 392, 32, 32), (1024, 392, 32, 32), (1024, 784, 32, 32)]
+shapes_1d = [(64, 1024*392), (256, 1024*392), (1024, 1024*392), (1024, 1024*784)]
+shapes_linear = [(64*1024, 392), (256*1024, 392), (1024*1024, 392), (1024*1024, 784)]
+
+# test_common(gpu_opl.matrix_elementwise_add_by_const, 1, shapes, has_const=True)
+# test_common(gpu_opl.matrix_elementwise_add, 2, shapes)
+# test_argmax(shapes)
+# test_common(gpu_opl.array_set, 1, shapes, False, False, 0.5)
+# test_pooling(gpu_opl.average_pooling2d, 1, shapes_conv, 3, 3, 1, 1)
+# test_matmul(shapes)
+# test_broadcast_to(shapes)
+# test_common(gpu_opl.clone, 1, shapes)
+# test_concat(shapes)
+# test_conv2d(shapes_conv)
+# test_reduce_sum(shapes_conv, [0, 2, 3])
+# test_cross_entropy(shapes_linear)
+# test_common(gpu_opl.matrix_dot, 2, shapes)
+# test_dropout(shapes)
+# test_common(gpu_opl.gelu, 1, shapes)
+# test_layernorm(shapes)
+# test_linear(shapes_linear)
+# test_common(gpu_opl.log_link, 1, shapes)
+# test_common(gpu_opl.CuDNN_softmax, 1, shapes_linear)
+# test_common(gpu_opl.sigmoid, 1, shapes)
+# test_slice(shapes, slices=[0, 512, 0])
+# test_transpose(shapes, [0, 2, 1])
+# test_common(gpu_opl.where, 3, shapes)

--- a/tests/test_transformer_ops.py
+++ b/tests/test_transformer_ops.py
@@ -281,7 +281,7 @@ def test_layer_norm_op(shape=(5, 3)):
     y_ = scale.reshape(bc_shape) * normed_input + \
         bias.reshape(bc_shape)
 
-    np.testing.assert_allclose(y_, y, atol=1e-6)
+    np.testing.assert_allclose(y_, y, rtol=1e-6, atol=1e-6)
     # print(y_)
 
     prev_grad = np.ones(y_.shape).astype(np.float32)
@@ -339,3 +339,4 @@ def test_layer_norm_op(shape=(5, 3)):
 test_layer_norm_op()
 test_layer_norm_op(shape=(4, 5, 6))
 test_layer_norm_op(shape=(2, 256, 768))
+test_layer_norm_op(shape=(2, 64, 3072))


### PR DESCRIPTION
# Test Method
accuracy test:
```bash
python tests/test_gpu_op.py
python tests/test_transformer_ops.py
```
performance test:
```bash
python tests/test_ops_speed.py
```

# Details
## Gelu & Sigmoid
fix some slight mistakes which result in low performance: 1.0->1.0f, erf()->erff(), etc
| Gelu        | (64, 1024, 392) | (256, 1024, 392) | (1024, 1024, 392) | (1024, 1024, 784) |
| ----------- | --------------- | ---------------- | ----------------- | ----------------- |
| PyTorch     | 0.488           | 1.76             | 6.21              | 12.38             |
| ours before | 8.594           | 31.1             | 96.2              | 191.5             |
| ours now    | 0.392           | 1.54             | 5.89              | 11.99             |


| Sigmoid     | (64, 1024, 392) | (256, 1024, 392) | (1024, 1024, 392) | (1024, 1024, 784) |
| ----------- | --------------- | ---------------- | ----------------- | ----------------- |
| PyTorch     | 0.57            | 1.69             | 6.32              | 12.34             |
| ours before | 3.51            | 0.92             | 44.3              | 80.08             |
| ours now    | 0.39            | 1.52             | 6.04              | 12.02             |


## Argmax
fix assert error

## LayerNorm
Using new algorithm to calculate `mean` and `var` which need only one loop:
![image](https://user-images.githubusercontent.com/77650497/188465001-d4381135-278d-4416-a447-78275aaaf978.png)
| LayerNorm   | (64, 1024, 392) | (256, 1024, 392) | (1024, 1024, 392) | (1024, 1024, 784) |
| ----------- | --------------- | ---------------- | ----------------- | ----------------- |
| PyTorch     | 0.77            | 2.09             | 6.36              | 12.96             |
| ours before | 4.11            | 14.7             | 56.6              | 117.4             |
| ours now    | 0.48            | 1.85             | 6.76              | 16.64             |

## Conv2d
Using `cudnnGetConvolutionForwardAlgorithm_v7` to choose the best conv2d algorithm according to remaining cuda memory instead of using `CUDNN_CONVOLUTION_FWD_PREFER_FASTEST ` only. OOM error will happen if we only select the fastest algorithm.

| Conv2D | (64, 392, 32, 32) | (256, 392, 32, 32) | (1024, 392, 32, 32) | (1024, 784, 32, 32) |
| ----------- | --------------- | ---------------- | ----------------- | ----------------- |
| PyTorch     | 11.05        | 48.08      | 399            | 1087        |
| ours before | 13.87    | 115         | OOM           | OOM          |
| ours now    | 14.25        | 49.27      | 414          | 1085          |