### PR TITLE
Fix sparse push block and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,9 +162,10 @@ The prerequisites for different modules in Hetu is listed as follows:
   Tips for preparing the prerequisites
   
   Preparing CUDA, CUDNN, CUB, NCCL(NCCl is already in conda environment):
-  1. download from https://developer.nvidia.com
-  2. install
-  3. modify paths in cmake/config.cmake if necessary
+  1. download from https://developer.nvidia.com 
+  2. download CUB from https://github.com/NVIDIA/cub/releases/tag/1.12.1
+  3. install
+  4. modify paths in cmake/config.cmake if necessary
   
   Preparing OpenMP:
   Your just need to ensure your compiler support openmp.

--- a/examples/nlp/bert/README.md
+++ b/examples/nlp/bert/README.md
@@ -34,6 +34,11 @@ To pretrain Hetu BERT base or BERT large model using data parallel distributedly
 sh ./scripts/train_hetu_bert_base_dp.sh
 sh ./scripts/train_hetu_bert_large_dp.sh
 ```
+To pretrain Hetu BERT base or BERT large model using PS, run:
+```bash
+sh ./scripts/train_hetu_bert_base_ps.sh
+sh ./scripts/train_hetu_bert_large_ps.sh
+```
 To pretrain Pytorch BERT base or BERT large model, run:
 ```bash
 sh ./scripts/train_pytorch_bert_base.sh

--- a/examples/nlp/bert/scripts/train_hetu_bert_large_ps.sh
+++ b/examples/nlp/bert/scripts/train_hetu_bert_large_ps.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+heturun -s 1 -w 4 python train_hetu_bert_ps.py \
+--train_batch_size 4 \
+--dataset wikicorpus_en \
+--vocab_size 30522 \
+--hidden_size 1024 \
+--num_hidden_layers 24 \
+--num_attention_heads 16 \
+--seq_length 128 \
+--epochs 20 \
+--lr 1e-5 \
+--adam_weight_decay 0.01 \
+--hidden_act relu \
+--dropout_prob 0.1

--- a/ps-lite/src/worker.cc
+++ b/ps-lite/src/worker.cc
@@ -148,7 +148,6 @@ void Worker::sparse_push(int node_name, const DLArray *index,
                                           -node_name);
         },
         indices, data, index_size, evt);
-    node2pushthread[node_name].wait();
 }
 
 void Worker::sd_pushpull(int node_name, const DLArray *index,


### PR DESCRIPTION
Closes #42 

The original sparse push error was due to the wrong context of `ParameterServerCommunicateOp`'s inputs, but this has been solved by the following code in the last PR #41. Therefore, it still works if we simply remove `node2pushthread[node_name].wait()`.

https://github.com/Hsword/Hetu/blob/a4877216fffd385723630a589c2f0060b51518be/python/hetu/gpu_ops/ParameterServerCommunicate.py#L132-L137


Besides, I add something about BERT-PS trainning scripts and CUB installation in README